### PR TITLE
ESA CCI SM: update reader and enable NoahMP4.0.1 plugin

### DIFF
--- a/ldt/DAobs/ESACCI_sm/readESACCIsmObs.F90
+++ b/ldt/DAobs/ESACCI_sm/readESACCIsmObs.F90
@@ -9,16 +9,17 @@
 !-------------------------END NOTICE -- DO NOT EDIT-----------------------
 #include "LDT_misc.h"
 !BOP
-! 
+!
 ! !ROUTINE: readESACCIsmObs
 ! \label{readESACCIsmObs}
-! 
-! !REVISION HISTORY: 
+!
+! !REVISION HISTORY:
 !  21 July 2010: Sujay Kumar, Initial Specification
-! 
-! !INTERFACE: 
+!  14 March 2021: Zdenko Heyvaert, added support for v5.2
+!
+! !INTERFACE:
 subroutine readESACCIsmObs(n)
-! !USES:   
+! !USES:
   use ESMF
   use LDT_coreMod,      only : LDT_rc
   use LDT_timeMgrMod,   only : LDT_get_julss
@@ -29,13 +30,13 @@ subroutine readESACCIsmObs(n)
   use map_utils
 
   implicit none
-! !ARGUMENTS: 
+! !ARGUMENTS:
   integer, intent(in) :: n
-! 
-! !DESCRIPTION: 
-! 
+!
+! !DESCRIPTION:
+!
 ! This subroutine provides the data reader for the ESACCI
-! soil moisture retrieval product. 
+! soil moisture retrieval product.
 !
 !EOP
 
@@ -47,7 +48,7 @@ subroutine readESACCIsmObs(n)
   real              :: smobs(LDT_rc%lnc(n)*LDT_rc%lnr(n))
 
 !-----------------------------------------------------------------------
-! It is assumed that CDF is computed using daily observations. 
+! It is assumed that CDF is computed using daily observations.
 !-----------------------------------------------------------------------
   ESACCIsmobs(n)%smobs = LDT_rc%udef
   smobs= LDT_rc%udef
@@ -55,17 +56,17 @@ subroutine readESACCIsmObs(n)
   call create_ESACCIsm_filename(ESACCIsmobs(n)%odir, &
        ESACCIsmobs(n)%version,&
        LDT_rc%yr, LDT_rc%mo, LDT_rc%da, fname)
-  
+
   inquire(file=trim(fname),exist=file_exists)
   if(file_exists) then
-     
+
      write(LDT_logunit,*) '[INFO] Reading ..',trim(fname)
      call read_ESACCI_data(n, fname,smobs)
      write(LDT_logunit,*) '[INFO] Finished reading ',trim(fname)
 
      do r=1,LDT_rc%lnr(n)
         do c=1,LDT_rc%lnc(n)
-           if(smobs(c+(r-1)*LDT_rc%lnc(n)).ne.-9999.0) then 
+           if(smobs(c+(r-1)*LDT_rc%lnc(n)).ne.-9999.0) then
               ESACCIsmobs(n)%smobs(c,r) = smobs(c+(r-1)*LDT_rc%lnc(n))
            endif
         enddo
@@ -79,14 +80,14 @@ end subroutine readESACCIsmObs
 
 
 !BOP
-! 
+!
 ! !ROUTINE: read_ESACCI_data
 ! \label(read_ESACCI_data)
 !
 ! !INTERFACE:
 subroutine read_ESACCI_data(n, fname, smobs_ip)
-! 
-! !USES:   
+!
+! !USES:
 #if(defined USE_NETCDF3 || defined USE_NETCDF4)
   use netcdf
 #endif
@@ -97,24 +98,24 @@ subroutine read_ESACCI_data(n, fname, smobs_ip)
 
   implicit none
 !
-! !INPUT PARAMETERS: 
-! 
-  integer                       :: n 
+! !INPUT PARAMETERS:
+!
+  integer                       :: n
   character (len=*)             :: fname
   real                          :: smobs_ip(LDT_rc%lnc(n)*LDT_rc%lnr(n))
 
 
 ! !OUTPUT PARAMETERS:
 !
-! !DESCRIPTION: 
+! !DESCRIPTION:
 !  This subroutine reads the ESACCI NETCDF file and applies the data
-!  quality flags to filter the data. The retrievals are rejected when 
-!  land surface temperature is below freezing, if rain is present, if 
+!  quality flags to filter the data. The retrievals are rejected when
+!  land surface temperature is below freezing, if rain is present, if
 !  RFI is present, if residual error is above 0.5 or if optical depth
 !  is above 0.8. Finally the routine combines both the C-band and X-band
-!  retrievals. 
-! 
-!  The arguments are: 
+!  retrievals.
+!
+!  The arguments are:
 !  \begin{description}
 !  \item[n]            index of the nest
 !  \item[fname]        name of the ESACCI AMSR-E file
@@ -123,10 +124,14 @@ subroutine read_ESACCI_data(n, fname, smobs_ip)
 !
 ! !FILES USED:
 !
-! !REVISION HISTORY: 
-! 
+! !REVISION HISTORY:
+!
 !EOP
-  integer           :: sm(ESACCIsmobs(n)%esaccinc,ESACCIsmobs(n)%esaccinr)
+!
+! real value instead of integer is required for soil moisture since v5.2
+
+!  integer           :: sm(ESACCIsmobs(n)%esaccinc,ESACCIsmobs(n)%esaccinr)
+  real              :: sm(ESACCIsmobs(n)%esaccinc,ESACCIsmobs(n)%esaccinr)
   integer           :: flag(ESACCIsmobs(n)%esaccinc,ESACCIsmobs(n)%esaccinr)
 
   real              :: sm_combined(ESACCIsmobs(n)%esaccinc,ESACCIsmobs(n)%esaccinr)
@@ -143,57 +148,67 @@ subroutine read_ESACCI_data(n, fname, smobs_ip)
 #if(defined USE_NETCDF3 || defined USE_NETCDF4)
   ios = nf90_open(path=trim(fname),mode=NF90_NOWRITE,ncid=nid)
   call LDT_verify(ios,'Error opening file '//trim(fname))
-  
+
   ios = nf90_inq_varid(nid, 'sm',smid)
   call LDT_verify(ios, 'Error nf90_inq_varid: sm')
-  
+
   ios = nf90_inq_varid(nid, 'flag',flagid)
   call LDT_verify(ios, 'Error nf90_inq_varid: flag')
-  
+
   !values
   ios = nf90_get_var(nid, smid, sm)
   call LDT_verify(ios, 'Error nf90_get_var: sm')
-  
+
   ios = nf90_get_var(nid, flagid,flag)
   call LDT_verify(ios, 'Error nf90_get_var: flag')
-  
+
   ios = nf90_close(ncid=nid)
   call LDT_verify(ios,'Error closing file '//trim(fname))
 
   do r=1, ESACCIsmobs(n)%esaccinr
      do c=1, ESACCIsmobs(n)%esaccinc
 !------------------------------------------------------------------------
-! All data flagged for snow coverage or temperature below zero (flag=1), 
-! dense vegetation (flag=2) and no convergence in the ESACCI algorithm 
-! (flag =3) and undefined values are masked out. 
+! All data flagged for snow coverage or temperature below zero (flag=1),
+! dense vegetation (flag=2) and no convergence in the ESACCI algorithm
+! (flag =3) and undefined values are masked out.
 !------------------------------------------------------------------------
-        
-        if(flag(c,r).ne.0.or.sm(c,r).lt.0) then 
+
+        if(flag(c,r).ne.0.or.sm(c,r).lt.0) then
            sm_combined(c,ESACCIsmobs(n)%esaccinr-r+1) = LDT_rc%udef
+!------------------------------------------------------------------------
+! Since v5.2, soil moisture values are directly stored in the ESA CCI
+! data files. For older versions, they were stored as integers
+! (10000x the value).
+!------------------------------------------------------------------------
+
         else
-           sm_combined(c,ESACCIsmobs(n)%esaccinr-r+1) = sm(c,r)*0.0001
+          if(ESACCIsmobs(n)%version.eq.5.2) then
+            sm_combined(c,ESACCIsmobs(n)%esaccinr-r+1) = sm(c,r)
+          else
+            sm_combined(c,ESACCIsmobs(n)%esaccinr-r+1) = sm(c,r)*0.0001
+          endif
         endif
      enddo
   enddo
- 
+
   do r=1, ESACCIsmobs(n)%esaccinr
      do c=1, ESACCIsmobs(n)%esaccinc
         sm_data(c+(r-1)*ESACCIsmobs(n)%esaccinc) = sm_combined(c,r)
-        if(sm_combined(c,r).ne.LDT_rc%udef) then 
-           sm_data_b(c+(r-1)*ESACCIsmobs(n)%esaccinc) = .true. 
+        if(sm_combined(c,r).ne.LDT_rc%udef) then
+           sm_data_b(c+(r-1)*ESACCIsmobs(n)%esaccinc) = .true.
         else
            sm_data_b(c+(r-1)*ESACCIsmobs(n)%esaccinc) = .false.
         endif
-        if(sm_combined(c,r).gt.0.5) then 
+        if(sm_combined(c,r).gt.0.5) then
            sm_combined(c,r) = LDT_rc%udef
            sm_data_b(c+(r-1)*ESACCIsmobs(n)%esaccinc) = .false.
         endif
      enddo
   enddo
-  
+
 !--------------------------------------------------------------------------
 ! Interpolate to the LDT running domain
-!-------------------------------------------------------------------------- 
+!--------------------------------------------------------------------------
   call neighbor_interp(LDT_rc%gridDesc(n,:),&
        sm_data_b, sm_data, smobs_b_ip, smobs_ip, &
        ESACCIsmobs(n)%esaccinc*ESACCIsmobs(n)%esaccinr, &
@@ -203,28 +218,28 @@ subroutine read_ESACCI_data(n, fname, smobs_ip)
        LDT_rc%udef, ios)
 
 #endif
-  
+
 end subroutine read_ESACCI_data
 
 !BOP
 ! !ROUTINE: create_ESACCIsm_filename
 ! \label{create_ESACCIsm_filename}
-! 
-! !INTERFACE: 
+!
+! !INTERFACE:
 subroutine create_ESACCIsm_filename(ndir, version, yr, mo,da, filename)
-! !USES:   
+! !USES:
 
   implicit none
-! !ARGUMENTS: 
+! !ARGUMENTS:
   character(len=*)  :: filename
   real              :: version
   integer           :: yr, mo, da
   character (len=*) :: ndir
-! 
-! !DESCRIPTION: 
-!  This subroutine creates the ESACCI filename based on the time and date 
-! 
-!  The arguments are: 
+!
+! !DESCRIPTION:
+!  This subroutine creates the ESACCI filename based on the time and date
+!
+!  The arguments are:
 !  \begin{description}
 !  \item[ndir] name of the ESACCI soil moisture directory
 !  \item[yr]  current year
@@ -236,19 +251,22 @@ subroutine create_ESACCIsm_filename(ndir, version, yr, mo,da, filename)
 
   character (len=4) :: fyr
   character (len=2) :: fmo,fda
-  
+
   write(unit=fyr, fmt='(i4.4)') yr
   write(unit=fmo, fmt='(i2.2)') mo
   write(unit=fda, fmt='(i2.2)') da
- 
-  if(version.eq.1) then 
+
+  if(version.eq.1) then
      filename = trim(ndir)//'/'//trim(fyr)//'/ESACCI-L3S_SOILMOISTURE-SSMV-MERGED-' &
           //trim(fyr)//trim(fmo)//trim(fda)//'000000-fv00.1.nc'
-  elseif(version.eq.2) then 
+  elseif(version.eq.2) then
      filename = trim(ndir)//'/'//trim(fyr)//'/ESACCI-SOILMOISTURE-L3S-SSMV-COMBINED-' &
           //trim(fyr)//trim(fmo)//trim(fda)//'000000-fv02.0.nc'
-  elseif(version.eq.2.2) then 
+  elseif(version.eq.2.2) then
      filename = trim(ndir)//'/'//trim(fyr)//'/ESACCI-SOILMOISTURE-L3S-SSMV-COMBINED-' &
           //trim(fyr)//trim(fmo)//trim(fda)//'000000-fv02.2.nc'
+  elseif(version.eq.5.2) then
+     filename = trim(ndir)//'/'//trim(fyr)//'/ESACCI-SOILMOISTURE-L3S-SSMV-COMBINED-' &
+          //trim(fyr)//trim(fmo)//trim(fda)//'000000-fv05.2.nc'
   endif
 end subroutine create_ESACCIsm_filename

--- a/lis/dataassim/obs/ESACCI_sm/read_ESACCIsm.F90
+++ b/lis/dataassim/obs/ESACCI_sm/read_ESACCIsm.F90
@@ -15,10 +15,11 @@
 ! !REVISION HISTORY:
 !  01 Oct 2012: Sujay Kumar, Initial Specification
 !  13 Jul 2016: Sujay Kumar, Updated the code to support DA in observation space
+!  14 March 2021: Zdenko Heyvaert, added support for v5.2
 !
-! !INTERFACE: 
+! !INTERFACE:
 subroutine read_ESACCIsm(n,k,  OBS_State, OBS_Pert_State)
-! !USES: 
+! !USES:
   use ESMF
   use LIS_mpiMod
   use LIS_coreMod
@@ -31,21 +32,21 @@ subroutine read_ESACCIsm(n,k,  OBS_State, OBS_Pert_State)
   use ESACCI_sm_Mod, only : ESACCI_sm_struc
 
   implicit none
-! !ARGUMENTS: 
-  integer, intent(in) :: n 
-  integer, intent(in) :: k 
+! !ARGUMENTS:
+  integer, intent(in) :: n
+  integer, intent(in) :: k
   type(ESMF_State)    :: OBS_State
   type(ESMF_State)    :: OBS_Pert_State
 !
 ! !DESCRIPTION:
-! 
+!
 ! This subroutine provides the data reader for the ESACCI
 ! soil moisture retrieval product. The routine also applies
-! online bias correction and LSM based quality control. The 
-! processed data is packaged into an ESMF State object for 
-! later use with DA. 
-!  
-!  The arguments are: 
+! online bias correction and LSM based quality control. The
+! processed data is packaged into an ESMF State object for
+! later use with DA.
+!
+!  The arguments are:
 !  \begin{description}
 !  \item[n] index of the nest
 !  \item[k] index of the data assimilation instance
@@ -85,7 +86,7 @@ subroutine read_ESACCIsm(n,k,  OBS_State, OBS_Pert_State)
   real, allocatable      :: ssdev(:)
   real                   :: model_delta(LIS_rc%obs_ngrid(k))
   real                   :: obs_delta(LIS_rc%obs_ngrid(k))
-  
+
   call ESMF_AttributeGet(OBS_State,"Data Directory",&
        smobsdir, rc=status)
   call LIS_verify(status, 'ESMF_AttributeGet failed in read_ESACCIsm')
@@ -93,21 +94,21 @@ subroutine read_ESACCIsm(n,k,  OBS_State, OBS_Pert_State)
        data_update, rc=status)
   call LIS_verify(status, 'ESMF_AttributeGet failed in read_ESACCIsm')
 
-  data_upd = .false. 
+  data_upd = .false.
   obs_unsc = LIS_rc%udef
 !-------------------------------------------------------------------------
 !   Read the data at 0Z and store it. The reference time is defined
-!   also as 0Z. 
+!   also as 0Z.
 !-------------------------------------------------------------------------
   alarmCheck = LIS_isAlarmRinging(LIS_rc, "ESACCI read alarm")
-  
-  if(alarmCheck.or.ESACCI_sm_struc(n)%startMode) then 
+
+  if(alarmCheck.or.ESACCI_sm_struc(n)%startMode) then
      ESACCI_sm_struc(n)%startMode = .false.
 
      ESACCI_sm_struc(n)%smobs = LIS_rc%udef
      smobs = LIS_rc%udef
      ESACCI_sm_struc(n)%smtime = -1
-     
+
      call create_ESACCIsm_filename(smobsdir, &
           ESACCI_sm_struc(n)%version, &
           LIS_rc%yr, LIS_rc%mo, &
@@ -115,8 +116,8 @@ subroutine read_ESACCIsm(n,k,  OBS_State, OBS_Pert_State)
 
      inquire(file=fname,exist=file_exists)
 
-     if(file_exists) then 
-        
+     if(file_exists) then
+
         write(LIS_logunit,*) 'Reading ',trim(fname)
         call read_ESACCI_data(n,k,fname,smobs)
 
@@ -127,13 +128,13 @@ subroutine read_ESACCIsm(n,k,  OBS_State, OBS_Pert_State)
      do r=1,LIS_rc%obs_lnr(k)
         do c=1,LIS_rc%obs_lnc(k)
            grid_index = LIS_obs_domain(n,k)%gindex(c,r)
-           if(grid_index.ne.-1) then 
-              if(smobs(c+(r-1)*LIS_rc%obs_lnc(k)).gt.0) then             
+           if(grid_index.ne.-1) then
+              if(smobs(c+(r-1)*LIS_rc%obs_lnc(k)).gt.0) then
                  ESACCI_sm_struc(n)%smobs(c,r) = &
-                      smobs(c+(r-1)*LIS_rc%obs_lnc(k))                 
+                      smobs(c+(r-1)*LIS_rc%obs_lnc(k))
 
                  lon = LIS_obs_domain(n,k)%lon(c+(r-1)*LIS_rc%obs_lnc(k))
-                 
+
                  lhour = 12.0
                  call LIS_localtime2gmt (gmt,lon,lhour,zone)
                  ESACCI_sm_struc(n)%smtime(c,r) = gmt
@@ -143,35 +144,35 @@ subroutine read_ESACCIsm(n,k,  OBS_State, OBS_Pert_State)
      enddo
 
   endif
-  
+
   call ESMF_StateGet(OBS_State,"Observation01",smfield,&
        rc=status)
   call LIS_verify(status, 'Error: StateGet Observation01')
-  
+
   call ESMF_FieldGet(smfield,localDE=0,farrayPtr=obsl,rc=status)
   call LIS_verify(status, 'Error: FieldGet')
-  
-  fnd = 0 
+
+  fnd = 0
   sm_current = LIS_rc%udef
- 
+
 ! dt is not defined as absolute value of the time difference to avoid
-! double counting of the data in assimilation. 
+! double counting of the data in assimilation.
 ! Assimilate at 12 z localtime
 
   do r=1,LIS_rc%obs_lnr(k)
      do c=1,LIS_rc%obs_lnc(k)
-        if(LIS_obs_domain(n,k)%gindex(c,r).ne.-1) then 
+        if(LIS_obs_domain(n,k)%gindex(c,r).ne.-1) then
            grid_index = c+(r-1)*LIS_rc%obs_lnc(k)
 
            dt = (LIS_rc%gmt - ESACCI_sm_struc(n)%smtime(c,r))*3600.0
-           if(dt.ge.0.and.dt.lt.LIS_rc%ts) then 
-              sm_current(c,r) = & 
+           if(dt.ge.0.and.dt.lt.LIS_rc%ts) then
+              sm_current(c,r) = &
                    ESACCI_sm_struc(n)%smobs(c,r)
-              if(LIS_obs_domain(n,k)%gindex(c,r).ne.-1) then 
+              if(LIS_obs_domain(n,k)%gindex(c,r).ne.-1) then
                  obs_unsc(LIS_obs_domain(n,k)%gindex(c,r)) = &
                       sm_current(c,r)
               endif
-              if(sm_current(c,r).ne.LIS_rc%udef) then 
+              if(sm_current(c,r).ne.LIS_rc%udef) then
                  fnd = 1
               endif
            endif
@@ -181,27 +182,27 @@ subroutine read_ESACCIsm(n,k,  OBS_State, OBS_Pert_State)
 
 !-------------------------------------------------------------------------
 !  Transform data to the LSM climatology using a CDF-scaling approach
-!-------------------------------------------------------------------------     
+!-------------------------------------------------------------------------
 
-  if(LIS_rc%dascaloption(k).ne."none".and.fnd.ne.0) then  
+  if(LIS_rc%dascaloption(k).ne."none".and.fnd.ne.0) then
      call LIS_rescale_with_CDF_matching(    &
-          n,k,                              & 
-          ESACCI_sm_struc(n)%nbins,         & 
-          ESACCI_sm_struc(n)%ntimes,        & 
-          MAX_SM_VALUE,                     & 
-          MIN_SM_VALUE,                     & 
+          n,k,                              &
+          ESACCI_sm_struc(n)%nbins,         &
+          ESACCI_sm_struc(n)%ntimes,        &
+          MAX_SM_VALUE,                     &
+          MIN_SM_VALUE,                     &
           ESACCI_sm_struc(n)%model_xrange,  &
           ESACCI_sm_struc(n)%obs_xrange,    &
           ESACCI_sm_struc(n)%model_cdf,     &
           ESACCI_sm_struc(n)%obs_cdf,       &
           sm_current)
-     
+
   endif
 
-  obsl = LIS_rc%udef 
+  obsl = LIS_rc%udef
   do r=1, LIS_rc%obs_lnr(k)
      do c=1, LIS_rc%obs_lnc(k)
-        if(LIS_obs_domain(n,k)%gindex(c,r).ne.-1) then 
+        if(LIS_obs_domain(n,k)%gindex(c,r).ne.-1) then
            obsl(LIS_obs_domain(n,k)%gindex(c,r))=sm_current(c,r)
         endif
      enddo
@@ -209,7 +210,7 @@ subroutine read_ESACCIsm(n,k,  OBS_State, OBS_Pert_State)
 
 !-------------------------------------------------------------------------
 !  Apply LSM-based QC and screening of observations
-!-------------------------------------------------------------------------     
+!-------------------------------------------------------------------------
 
   call lsmdaqcobsstate(trim(LIS_rc%lsm)//"+"&
        //trim(LIS_ESACCIsmobsId)//char(0),n, k,OBS_state)
@@ -217,12 +218,12 @@ subroutine read_ESACCIsm(n,k,  OBS_State, OBS_Pert_State)
   call LIS_checkForValidObs(n,k,obsl,fnd,sm_current)
 
 
-  if(fnd.eq.0) then 
-     data_upd_flag_local = .false. 
+  if(fnd.eq.0) then
+     data_upd_flag_local = .false.
   else
-     data_upd_flag_local = .true. 
+     data_upd_flag_local = .true.
   endif
-        
+
 #if (defined SPMD)
   call MPI_ALLGATHER(data_upd_flag_local,1, &
        MPI_LOGICAL, data_upd_flag(:),&
@@ -232,28 +233,28 @@ subroutine read_ESACCIsm(n,k,  OBS_State, OBS_Pert_State)
   do p=1,LIS_npes
      data_upd = data_upd.or.data_upd_flag(p)
   enddo
-  
-  if(data_upd) then 
+
+  if(data_upd) then
      do t=1,LIS_rc%obs_ngrid(k)
         gid(t) = t
-        if(obsl(t).ne.-9999.0) then 
+        if(obsl(t).ne.-9999.0) then
            assimflag(t) = 1
         else
            assimflag(t) = 0
         endif
      enddo
-  
+
      call ESMF_AttributeSet(OBS_State,"Data Update Status",&
           .true. , rc=status)
      call LIS_verify(status,&
           'ESMF_AttributeSet: Data Update Status failed in read_ESACCIsm')
 
-     if(LIS_rc%obs_ngrid(k).gt.0) then 
+     if(LIS_rc%obs_ngrid(k).gt.0) then
         call ESMF_AttributeSet(smField,"Grid Number",&
              gid,itemCount=LIS_rc%obs_ngrid(k),rc=status)
         call LIS_verify(status,&
-             'ESMF_AttributeSet: Grid Number failed in read_ESACCIsm')          
-  
+             'ESMF_AttributeSet: Grid Number failed in read_ESACCIsm')
+
         call ESMF_AttributeSet(smField,"Assimilation Flag",&
              assimflag,itemCount=LIS_rc%obs_ngrid(k),rc=status)
         call LIS_verify(status,&
@@ -261,11 +262,11 @@ subroutine read_ESACCIsm(n,k,  OBS_State, OBS_Pert_State)
 
         call ESMF_AttributeSet(smfield, "Unscaled Obs",&
              obs_unsc, itemCount=LIS_rc%obs_ngrid(k), rc=status)
-        call LIS_verify(status, 'Error in setting Unscaled Obs attribute')      
+        call LIS_verify(status, 'Error in setting Unscaled Obs attribute')
      endif
 
      if(ESACCI_sm_struc(n)%useSsdevScal.eq.1.and.&
-          ESACCI_sm_struc(n)%ntimes.gt.1) then 
+          ESACCI_sm_struc(n)%ntimes.gt.1) then
 
         call ESMF_StateGet(OBS_Pert_State,"Observation01",pertfield,&
              rc=status)
@@ -273,24 +274,24 @@ subroutine read_ESACCIsm(n,k,  OBS_State, OBS_Pert_State)
 
         allocate(ssdev(LIS_rc%obs_ngrid(k)))
         ssdev = ESACCI_sm_struc(n)%ssdev_inp
-        if(ESACCI_sm_struc(n)%ntimes.eq.1) then 
+        if(ESACCI_sm_struc(n)%ntimes.eq.1) then
            jj = 1
         else
            jj = LIS_rc%mo
         endif
 
         do t=1,LIS_rc%obs_ngrid(k)
-           if(ESACCI_sm_struc(n)%obs_sigma(t,jj).gt.0) then 
+           if(ESACCI_sm_struc(n)%obs_sigma(t,jj).gt.0) then
               ssdev(t) = ssdev(t)*ESACCI_sm_struc(n)%model_sigma(t,jj)/&
                    ESACCI_sm_struc(n)%obs_sigma(t,jj)
               if(ssdev(t).gt.maxssdev) ssdev(t) = maxssdev
-              if(ssdev(t).lt.minssdev) then 
+              if(ssdev(t).lt.minssdev) then
                  ssdev(t) = minssdev
               endif
            endif
         enddo
 
-        if(LIS_rc%obs_ngrid(k).gt.0) then 
+        if(LIS_rc%obs_ngrid(k).gt.0) then
            call ESMF_AttributeSet(pertField,"Standard Deviation",&
                 ssdev,itemCount=LIS_rc%obs_ngrid(k),rc=status)
            call LIS_verify(status)
@@ -303,21 +304,21 @@ subroutine read_ESACCIsm(n,k,  OBS_State, OBS_Pert_State)
      call ESMF_AttributeSet(OBS_State,"Data Update Status",&
           .false., rc=status)
      call LIS_verify(status,&
-          'ESMF_AttributeSet: Data Update Status failed in read_ESACCIsm')     
+          'ESMF_AttributeSet: Data Update Status failed in read_ESACCIsm')
   endif
 
 end subroutine read_ESACCIsm
 
 
 !BOP
-! 
+!
 ! !ROUTINE: read_ESACCI_data
 ! \label{read_ESACCI_data}
 !
 ! !INTERFACE:
 subroutine read_ESACCI_data(n, k, fname, smobs_ip)
-! 
-! !USES:   
+!
+! !USES:
 #if(defined USE_NETCDF3 || defined USE_NETCDF4)
   use netcdf
 #endif
@@ -327,9 +328,9 @@ subroutine read_ESACCI_data(n, k, fname, smobs_ip)
 
   implicit none
 !
-! !INPUT PARAMETERS: 
-! 
-  integer                       :: n 
+! !INPUT PARAMETERS:
+!
+  integer                       :: n
   integer                       :: k
   character (len=*)             :: fname
   real                          :: smobs_ip(LIS_rc%obs_lnc(k)*LIS_rc%obs_lnr(k))
@@ -337,13 +338,13 @@ subroutine read_ESACCI_data(n, k, fname, smobs_ip)
 
 ! !OUTPUT PARAMETERS:
 !
-! !DESCRIPTION: 
+! !DESCRIPTION:
 !  This subroutine reads the ESACCI NETCDF file and applies the data
 !  quality flags to filter the data.The data quality flags provided
 !  with the data is applied by excluding data masked for dense vegetation,
-!  temperature below zero and lack of convergence of the algorithm. 
-! 
-!  The arguments are: 
+!  temperature below zero and lack of convergence of the algorithm.
+!
+!  The arguments are:
 !  \begin{description}
 !  \item[n]            index of the nest
 !  \item[fname]        name of the ESACCI AMSR-E file
@@ -352,10 +353,14 @@ subroutine read_ESACCI_data(n, k, fname, smobs_ip)
 !
 ! !FILES USED:
 !
-! !REVISION HISTORY: 
-! 
+! !REVISION HISTORY:
+!
 !EOP
-  integer      :: sm(ESACCI_sm_struc(n)%ecvnc,ESACCI_sm_struc(n)%ecvnr)
+!
+! real value instead of integer is required for soil moisture since v5.2
+
+!  integer      :: sm(ESACCI_sm_struc(n)%ecvnc,ESACCI_sm_struc(n)%ecvnr)
+  real         :: sm(ESACCI_sm_struc(n)%ecvnc,ESACCI_sm_struc(n)%ecvnr)
   integer      :: flag(ESACCI_sm_struc(n)%ecvnc,ESACCI_sm_struc(n)%ecvnr)
 
   real         :: sm_combined(ESACCI_sm_struc(n)%ecvnc,ESACCI_sm_struc(n)%ecvnr)
@@ -372,57 +377,67 @@ subroutine read_ESACCI_data(n, k, fname, smobs_ip)
 #if(defined USE_NETCDF3 || defined USE_NETCDF4)
   ios = nf90_open(path=trim(fname),mode=NF90_NOWRITE,ncid=nid)
   call LIS_verify(ios,'Error opening file '//trim(fname))
-  
+
   ios = nf90_inq_varid(nid, 'sm',smid)
   call LIS_verify(ios, 'Error nf90_inq_varid: sm')
-  
+
   ios = nf90_inq_varid(nid, 'flag',flagid)
   call LIS_verify(ios, 'Error nf90_inq_varid: flag')
-  
+
   !values
   ios = nf90_get_var(nid, smid, sm)
   call LIS_verify(ios, 'Error nf90_get_var: sm')
-  
+
   ios = nf90_get_var(nid, flagid,flag)
   call LIS_verify(ios, 'Error nf90_get_var: flag')
-  
+
   ios = nf90_close(ncid=nid)
   call LIS_verify(ios,'Error closing file '//trim(fname))
 
   do r=1, ESACCI_sm_struc(n)%ecvnr
      do c=1, ESACCI_sm_struc(n)%ecvnc
 !------------------------------------------------------------------------
-! All data flagged for snow coverage or temperature below zero (flag=1), 
-! dense vegetation (flag=2) and no convergence in the ESACCI algorithm 
-! (flag =3) and undefined values are masked out. 
+! All data flagged for snow coverage or temperature below zero (flag=1),
+! dense vegetation (flag=2) and no convergence in the ESACCI algorithm
+! (flag =3) and undefined values are masked out.
 !------------------------------------------------------------------------
-        
-        if(flag(c,r).ne.0.or.sm(c,r).le.0) then 
+
+        if(flag(c,r).ne.0.or.sm(c,r).le.0) then
            sm_combined(c,ESACCI_sm_struc(n)%ecvnr-r+1) = LIS_rc%udef
+!------------------------------------------------------------------------
+! Since v5.2, soil moisture values are directly stored in the ESA CCI
+! data files. For older versions, they were stored as integers
+! (10000x the value).
+!------------------------------------------------------------------------
+
         else
-           sm_combined(c,ESACCI_sm_struc(n)%ecvnr-r+1) = sm(c,r)*0.0001
+          if(ESACCI_sm_struc(n)%version.eq.5.2) then
+            sm_combined(c,ESACCI_sm_struc(n)%ecvnr-r+1) = sm(c,r)
+          else
+            sm_combined(c,ESACCI_sm_struc(n)%ecvnr-r+1) = sm(c,r)*0.0001
+          endif
         endif
      enddo
   enddo
- 
+
   do r=1, ESACCI_sm_struc(n)%ecvnr
      do c=1, ESACCI_sm_struc(n)%ecvnc
         sm_data(c+(r-1)*ESACCI_sm_struc(n)%ecvnc) = sm_combined(c,r)
-        if(sm_combined(c,r).ne.LIS_rc%udef) then 
-           sm_data_b(c+(r-1)*ESACCI_sm_struc(n)%ecvnc) = .true. 
+        if(sm_combined(c,r).ne.LIS_rc%udef) then
+           sm_data_b(c+(r-1)*ESACCI_sm_struc(n)%ecvnc) = .true.
         else
            sm_data_b(c+(r-1)*ESACCI_sm_struc(n)%ecvnc) = .false.
         endif
-        if(sm_combined(c,r).gt.0.5) then 
+        if(sm_combined(c,r).gt.0.5) then
            sm_combined(c,r) = LIS_rc%udef
            sm_data_b(c+(r-1)*ESACCI_sm_struc(n)%ecvnc) = .false.
         endif
      enddo
   enddo
-  
+
 !--------------------------------------------------------------------------
 ! Interpolate to the DA observation space
-!-------------------------------------------------------------------------- 
+!--------------------------------------------------------------------------
   call neighbor_interp(LIS_rc%obs_gridDesc(k,:),&
        sm_data_b, sm_data, smobs_b_ip, smobs_ip, &
        ESACCI_sm_struc(n)%ecvnc*ESACCI_sm_struc(n)%ecvnr, &
@@ -431,28 +446,28 @@ subroutine read_ESACCI_data(n, k, fname, smobs_ip)
        ESACCI_sm_struc(n)%n11,LIS_rc%udef, ios)
 
 #endif
-  
+
 end subroutine read_ESACCI_data
 
 !BOP
 ! !ROUTINE: create_ESACCIsm_filename
 ! \label{create_ESACCIsm_filename}
-! 
-! !INTERFACE: 
+!
+! !INTERFACE:
 subroutine create_ESACCIsm_filename(ndir, version, yr, mo,da, filename)
-! !USES:   
+! !USES:
 
   implicit none
-! !ARGUMENTS: 
+! !ARGUMENTS:
   character(len=*)  :: filename
   real              :: version
   integer           :: yr, mo, da
   character (len=*) :: ndir
-! 
-! !DESCRIPTION: 
-!  This subroutine creates the ESACCI filename based on the time and date 
-! 
-!  The arguments are: 
+!
+! !DESCRIPTION:
+!  This subroutine creates the ESACCI filename based on the time and date
+!
+!  The arguments are:
 !  \begin{description}
 !  \item[ndir] name of the ESACCI soil moisture directory
 !  \item[yr]  current year
@@ -464,26 +479,28 @@ subroutine create_ESACCIsm_filename(ndir, version, yr, mo,da, filename)
 
   character (len=4) :: fyr
   character (len=2) :: fmo,fda
-  
+
   write(unit=fyr, fmt='(i4.4)') yr
   write(unit=fmo, fmt='(i2.2)') mo
   write(unit=fda, fmt='(i2.2)') da
- 
-  if(version.eq.1) then 
+
+  if(version.eq.1) then
      filename = trim(ndir)//'/'//trim(fyr)//&
           '/ESACCI-L3S_SOILMOISTURE-SSMV-MERGED-' &
           //trim(fyr)//trim(fmo)//trim(fda)//'000000-fv00.1.nc'
-     
-  elseif(version.eq.2) then 
+
+  elseif(version.eq.2) then
      filename = trim(ndir)//'/'//trim(fyr)//&
-          '/ESACCI-SOILMOISTURE-L3S-SSMV-COMBINED-' & 
+          '/ESACCI-SOILMOISTURE-L3S-SSMV-COMBINED-' &
           //trim(fyr)//trim(fmo)//trim(fda)//'000000-fv02.0.nc'
-  elseif(version.eq.2.2) then 
+  elseif(version.eq.2.2) then
      filename = trim(ndir)//'/'//trim(fyr)//&
-          '/ESACCI-SOILMOISTURE-L3S-SSMV-COMBINED-' & 
+          '/ESACCI-SOILMOISTURE-L3S-SSMV-COMBINED-' &
           //trim(fyr)//trim(fmo)//trim(fda)//'000000-fv02.2.nc'
+
+  elseif(version.eq.5.2) then
+     filename = trim(ndir)//'/'//trim(fyr)//&
+          '/ESACCI-SOILMOISTURE-L3S-SSMV-COMBINED-' &
+          //trim(fyr)//trim(fmo)//trim(fda)//'000000-fv05.2.nc'
   endif
 end subroutine create_ESACCIsm_filename
-
-
-

--- a/lis/plugins/LIS_lsmda_pluginMod.F90
+++ b/lis/plugins/LIS_lsmda_pluginMod.F90
@@ -23,7 +23,7 @@ module LIS_lsmda_pluginMod
 !  30 Oct 2014: David Mocko, re-organized and added Noah-3.6
 !  1  Aug 2016: Mahdi Navari, added NoahMP.3.6
 !  Sep 2017: Mahdi Navari added JULES 5.0
-!  Oct  2018 : Mhdi Navari , added Noah.3.9 
+!  Oct  2018 : Mhdi Navari , added Noah.3.9
 !  21 Oct 2018: Mahdi Navari, added NoahMP.3.9
 !  Dec 2018: Mahdi Navari: added Noah-MP.4.0.1
 !  13 May 2019: Yeosang Yoon, added SNODEP & LDTSI Assimilation for NoahMP.4.0.1
@@ -32,6 +32,7 @@ module LIS_lsmda_pluginMod
 !                            enabled the compilation of JULES 5.3 DA
 !  13 Dec 2019: Eric Kemp, replaced LDTSI with USAFSI
 !  17 Feb 2020: Yeosang Yoon, added SNODEP & USAFSI Assimilation for Jules 5.x
+!  19 Apr 2021: Zdenko Heyvaert, added ESA CCI SM Assimilation for NoahMP.4.0.1
 !
 !EOP
   implicit none
@@ -186,7 +187,7 @@ subroutine LIS_lsmda_plugin
 #endif
 
 #if ( defined SM_NOAHMP_3_6 )
-   use noahmp36_dasoilm_Mod 
+   use noahmp36_dasoilm_Mod
    use noahmp36_dasnow_Mod
    use noahmp36_dasnodep_Mod
    use noahmp36_tws_DAlogMod, only : noahmp36_tws_DAlog
@@ -396,8 +397,8 @@ subroutine LIS_lsmda_plugin
 
 #if ( defined SM_NOAHMP_3_6 )
 ! MN: Noahmp-3.6 soil moisture
-   external noahmp36_getsoilm           
-   external noahmp36_setsoilm              
+   external noahmp36_getsoilm
+   external noahmp36_setsoilm
    external noahmp36_getsmpred
 !   external noahmp36_getLbandTbPred   !I think we need this for real Lband DA
    external noahmp36_qcsoilm
@@ -439,8 +440,8 @@ subroutine LIS_lsmda_plugin
    external noahmp36_descale_tws
    external noahmp36_updatetws
 
-   external noahmp36_getvegvars          
-   external noahmp36_setvegvars  
+   external noahmp36_getvegvars
+   external noahmp36_setvegvars
    external noahmp36_transform_veg
    external noahmp36_map_veg
    external noahmp36_updatevegvars
@@ -450,8 +451,8 @@ subroutine LIS_lsmda_plugin
    external noahmp36_scale_veg
    external noahmp36_descale_veg
 
-   external noahmp36_getalbedovars          
-   external noahmp36_setalbedovars  
+   external noahmp36_getalbedovars
+   external noahmp36_setalbedovars
    external noahmp36_updatealbedovars
    external noahmp36_qcalbedo
    external noahmp36_getalbedopred
@@ -463,10 +464,10 @@ subroutine LIS_lsmda_plugin
    external noahmp36_map_albedo
 #endif
 
-#if ( defined SM_NOAHMP_4_0_1 ) 
+#if ( defined SM_NOAHMP_4_0_1 )
 ! MN NoahMP.4.0.1 Soil moisture DA
-   external NoahMP401_getsoilm           
-   external NoahMP401_setsoilm              
+   external NoahMP401_getsoilm
+   external NoahMP401_setsoilm
    external NoahMP401_getsmpred
    external NoahMP401_qcsoilm
    external NoahMP401_qc_soilmobs
@@ -474,8 +475,8 @@ subroutine LIS_lsmda_plugin
    external NoahMP401_descale_soilm
    external NoahMP401_updatesoilm
 
-   external NoahMP401_getsnowvars         
-   external NoahMP401_setsnowvars              
+   external NoahMP401_getsnowvars
+   external NoahMP401_setsnowvars
    external NoahMP401_getsnowpred
    external NoahMP401_getswepred
    external NoahMP401_qcsnow
@@ -1208,7 +1209,7 @@ subroutine LIS_lsmda_plugin
    call registerlsmdaqcstate(trim(LIS_noah33Id)//"+"//&
         trim(LIS_synsndId)//char(0),noah33_qcsnow)
    call registerlsmdaqcobsstate(trim(LIS_noah33Id)//"+"//&
-        trim(LIS_synsndId)//char(0),noah33_qc_snowobs) 
+        trim(LIS_synsndId)//char(0),noah33_qc_snowobs)
    call registerlsmdascalestatevar(trim(LIS_noah33Id)//"+"//&
         trim(LIS_synsndId)//char(0),noah33_scale_snow)
    call registerlsmdadescalestatevar(trim(LIS_noah33Id)//"+"//&
@@ -1360,7 +1361,7 @@ subroutine LIS_lsmda_plugin
    call registerlsmdaupdatestate(trim(LIS_noah36Id)//"+"//&
         trim(LIS_SMOPSsmobsId)//char(0),noah36_updatesoilm)
 
-! MN 
+! MN
 ! Noah-3.6 RT SMOPS ASCAT soil moisture
    call registerlsmdainit(trim(LIS_noah36Id)//"+"//&
         trim(LIS_SMOPS_ASCATsmobsId)//char(0),noah36_dasoilm_init)
@@ -1752,7 +1753,7 @@ subroutine LIS_lsmda_plugin
 
 #if ( defined SM_NOAH_3_9 )
 
-! Noah-3.9 RT SMOPS ASCAT soil moisture! MN 
+! Noah-3.9 RT SMOPS ASCAT soil moisture! MN
    call registerlsmdainit(trim(LIS_noah39Id)//"+"//&
         trim(LIS_SMOPS_ASCATsmobsId)//char(0),noah39_dasoilm_init)
    call registerlsmdagetstatevar(trim(LIS_noah39Id)//"+"//&
@@ -1961,7 +1962,7 @@ subroutine LIS_lsmda_plugin
    call registerlsmdaqcstate(trim(LIS_noahmp36Id)//"+"//&
         trim(LIS_synsndId)//char(0),noahmp36_qcsnow)
    call registerlsmdaqcobsstate(trim(LIS_noahmp36Id)//"+"//&
-        trim(LIS_synsndId)//char(0),noahmp36_qc_snowobs) 
+        trim(LIS_synsndId)//char(0),noahmp36_qc_snowobs)
    call registerlsmdascalestatevar(trim(LIS_noahmp36Id)//"+"//&
         trim(LIS_synsndId)//char(0),noahmp36_scale_snow)
    call registerlsmdadescalestatevar(trim(LIS_noahmp36Id)//"+"//&
@@ -2008,7 +2009,7 @@ subroutine LIS_lsmda_plugin
    call registerlsmdaqcstate(trim(LIS_noahmp36Id)//"+"//&
         trim(LIS_synsweId)//char(0),noahmp36_qcsnow)
    call registerlsmdaqcobsstate(trim(LIS_noahmp36Id)//"+"//&
-        trim(LIS_synsweId)//char(0),noahmp36_qc_snowobs) 
+        trim(LIS_synsweId)//char(0),noahmp36_qc_snowobs)
    call registerlsmdascalestatevar(trim(LIS_noahmp36Id)//"+"//&
         trim(LIS_synsweId)//char(0),noahmp36_scale_snow)
    call registerlsmdadescalestatevar(trim(LIS_noahmp36Id)//"+"//&
@@ -2030,7 +2031,7 @@ subroutine LIS_lsmda_plugin
    call registerlsmdaqcstate(trim(LIS_noahmp36Id)//"+"//&
         trim(LIS_ASOsweobsId)//char(0),noahmp36_qcsnow)
    call registerlsmdaqcobsstate(trim(LIS_noahmp36Id)//"+"//&
-        trim(LIS_ASOsweobsId)//char(0),noahmp36_qc_snowobs) 
+        trim(LIS_ASOsweobsId)//char(0),noahmp36_qc_snowobs)
    call registerlsmdascalestatevar(trim(LIS_noahmp36Id)//"+"//&
         trim(LIS_ASOsweobsId)//char(0),noahmp36_scale_snow)
    call registerlsmdadescalestatevar(trim(LIS_noahmp36Id)//"+"//&
@@ -2438,6 +2439,27 @@ subroutine LIS_lsmda_plugin
    call registerlsmdaupdatestate(trim(LIS_noahmp401Id)//"+"//&
         trim(LIS_NASASMAPsmobsId )//char(0),NoahMP401_updatesoilm)
 
+!ZH
+! Noah-MP.4.0.1 ESACCI soil moisture
+   call registerlsmdainit(trim(LIS_noahmp401Id)//"+"//&
+        trim(LIS_ESACCIsmobsId)//char(0),NoahMP401_dasoilm_init)
+   call registerlsmdagetstatevar(trim(LIS_noahmp401Id)//"+"//&
+        trim(LIS_ESACCIsmobsId)//char(0),NoahMP401_getsoilm)
+   call registerlsmdasetstatevar(trim(LIS_noahmp401Id)//"+"//&
+        trim(LIS_ESACCIsmobsId)//char(0),NoahMP401_setsoilm)
+   call registerlsmdagetobspred(trim(LIS_noahmp401Id)//"+"//&
+        trim(LIS_ESACCIsmobsId)//char(0),NoahMP401_getsmpred)
+   call registerlsmdaqcstate(trim(LIS_noahmp401Id)//"+"//&
+        trim(LIS_ESACCIsmobsId)//char(0),NoahMP401_qcsoilm)
+   call registerlsmdaqcobsstate(trim(LIS_noahmp401Id)//"+"//&
+        trim(LIS_ESACCIsmobsId)//char(0),NoahMP401_qc_soilmobs)
+   call registerlsmdascalestatevar(trim(LIS_noahmp401Id)//"+"//&
+        trim(LIS_ESACCIsmobsId)//char(0),NoahMP401_scale_soilm)
+   call registerlsmdadescalestatevar(trim(LIS_noahmp401Id)//"+"//&
+        trim(LIS_ESACCIsmobsId)//char(0),NoahMP401_descale_soilm)
+   call registerlsmdaupdatestate(trim(LIS_noahmp401Id)//"+"//&
+        trim(LIS_ESACCIsmobsId)//char(0),NoahMP401_updatesoilm)
+
 !YK
 ! Noah-MP.4.0.1 SMOS NRT NN soil moisture
    call registerlsmdainit(trim(LIS_noahmp401Id)//"+"//&
@@ -2470,7 +2492,7 @@ subroutine LIS_lsmda_plugin
    call registerlsmdaqcstate(trim(LIS_noahmp401Id)//"+"//&
         trim(LIS_synsndId)//char(0),noahmp401_qcsnow)
    call registerlsmdaqcobsstate(trim(LIS_noahmp401Id)//"+"//&
-        trim(LIS_synsndId)//char(0),noahmp401_qc_snowobs) 
+        trim(LIS_synsndId)//char(0),noahmp401_qc_snowobs)
    call registerlsmdascalestatevar(trim(LIS_noahmp401Id)//"+"//&
         trim(LIS_synsndId)//char(0),noahmp401_scale_snow)
    call registerlsmdadescalestatevar(trim(LIS_noahmp401Id)//"+"//&
@@ -3593,7 +3615,7 @@ subroutine LIS_lsmda_plugin
    call registerlsmdaqcobsstate(trim(LIS_jules5xId)//"+"//&
         trim(LIS_usafsiobsId)//char(0),jules5x_qc_usafsiobs)
 #endif
-#endif 
+#endif
 
 #endif  !endif for DA_DIRECT_INSERTION, DA_ENKS, or DA_ENKF
 


### PR DESCRIPTION
**ESA CCI reader**
Updated the ESA CCI SM reader in both LIS and LDT so it also works for version 5.2.
- Change filenames;
- Change the soil moisture data type: `real` instead of `integer` (older versions: soil moisture was multiplied by 1e4, but this is not the case for v5.2).

**ESA CCI plug-in**
Enabled using ESA CCI SM data in combination with the NoahMP4.0.1 model.