### PR TITLE
BIG: Fix for writeout of spread+incr for multiple DA instances

### DIFF
--- a/lis/dataassim/algorithm/enkf/enkf_Mod.F90
+++ b/lis/dataassim/algorithm/enkf/enkf_Mod.F90
@@ -984,7 +984,10 @@ contains
             LIS_rc%nstvars(k),state_size, stvar)
 
        do v=1,LIS_rc%nstvars(k)
-          call LIS_writevar_spread(ftn,n,k,ensspread_id(v), &
+       ! Michel Bechtold, 2022/02/28, wrong use of DA instance index k       
+       ! call LIS_writevar_spread(ftn,n,k,ensspread_id(v), &
+       !     stvar(v,:),v)
+          call LIS_writevar_spread(ftn,n,LIS_rc%lsm_index,ensspread_id(v), &
                stvar(v,:),v)
        enddo
        
@@ -1116,7 +1119,10 @@ contains
        endif
        
        do v=1,LIS_rc%nstvars(k)
-          call LIS_writevar_incr(ftn,n,k,incr_id(v), &
+       ! Michel Bechtold, 2022/02/28, wrong use of DA instance index k       
+       ! call LIS_writevar_incr(ftn,n,k,incr_id(v), &
+       !   enkf_struc(n,k)%anlys_incr(v,:),v)
+          call LIS_writevar_incr(ftn,n,LIS_rc%lsm_index,incr_id(v), &
                enkf_struc(n,k)%anlys_incr(v,:),v)
        enddo
        


### PR DESCRIPTION
Bug Description

bug in dataassim/algorithm/enkf/enkf_Mod.F90
Wrong use of DA instance index k in write out of spread and incr.
In LIS_writevar_spread and LIS_writevar_incr the k was used for mtype, which is wrong. It should be LIS_rc%lsm_index instead of k.

Bug fix:
....
do v=1,LIS_rc%nstvars(k)
! Michel Bechtold, 2022/02/28, wrong use of DA instance index k
! call LIS_writevar_spread(ftn,n,k,ensspread_id(v), &
! stvar(v,:),v)
call LIS_writevar_spread(ftn,n,LIS_rc%lsm_index,ensspread_id(v), &
stvar(v,:),v)
enddo
....
do v=1,LIS_rc%nstvars(k)
! Michel Bechtold, 2022/02/28, wrong use of DA instance index k
! call LIS_writevar_incr(ftn,n,k,incr_id(v), &
! enkf_struc(n,k)%anlys_incr(v,:),v)
call LIS_writevar_incr(ftn,n,LIS_rc%lsm_index,incr_id(v), &
enkf_struc(n,k)%anlys_incr(v,:),v)
enddo
....
Steps to replicate

You can check spread and incr output for any testcase you have for multiple DA instances.