### PR TITLE
2 Bugfixes: negative deltalon in map_utils.f90 and CGLS LAI reader fix

### DIFF
--- a/lis/dataassim/obs/CGLS_LAI/CGLSlai_Mod.F90
+++ b/lis/dataassim/obs/CGLS_LAI/CGLSlai_Mod.F90
@@ -245,7 +245,7 @@ contains
                 call ESMF_ConfigFindLabel(LIS_config,"CGLS LAI lat max:",&
                      rc=status)
                 if (status .ne. 0) then
-                    CGLSlai_struc(n)%latmax = 90 - 0.5 * CGLSlai_struc(n)%spatialres
+                    CGLSlai_struc(n)%latmax = 90. - 0.5 * CGLSlai_struc(n)%spatialres
                 else
                     call ESMF_ConfigGetAttribute(LIS_config,CGLSlai_struc(n)%latmax,&
                          rc=status)
@@ -254,7 +254,7 @@ contains
                 call ESMF_ConfigFindLabel(LIS_config,"CGLS LAI lat min:",&
                      rc=status)
                 if (status .ne. 0) then
-                    CGLSlai_struc(n)%latmin = -90 + 0.5 * CGLSlai_struc(n)%spatialres
+                    CGLSlai_struc(n)%latmin = -90. + 0.5 * CGLSlai_struc(n)%spatialres
                 else
                     call ESMF_ConfigGetAttribute(LIS_config,CGLSlai_struc(n)%latmin,&
                          rc=status)
@@ -262,7 +262,7 @@ contains
                 call ESMF_ConfigFindLabel(LIS_config,"CGLS LAI lon max:",&
                      rc=status)
                 if (status .ne. 0) then
-                    CGLSlai_struc(n)%lonmax = 180 - 0.5 * CGLSlai_struc(n)%spatialres
+                    CGLSlai_struc(n)%lonmax = 180. - 0.5 * CGLSlai_struc(n)%spatialres
                 else
                     call ESMF_ConfigGetAttribute(LIS_config,CGLSlai_struc(n)%lonmax,&
                          rc=status)
@@ -270,7 +270,7 @@ contains
                 call ESMF_ConfigFindLabel(LIS_config,"CGLS LAI lon min:",&
                      rc=status)
                 if (status .ne. 0) then
-                    CGLSlai_struc(n)%lonmin = -180 + 0.5 * CGLSlai_struc(n)%spatialres
+                    CGLSlai_struc(n)%lonmin = -180. + 0.5 * CGLSlai_struc(n)%spatialres
                 else
                     call ESMF_ConfigGetAttribute(LIS_config,CGLSlai_struc(n)%lonmin,&
                          rc=status)
@@ -283,9 +283,9 @@ contains
                 CGLSlai_struc(n)%nc = nint((CGLSlai_struc(n)%lonmax - CGLSlai_struc(n)%lonmin)&
                                            / CGLSlai_struc(n)%spatialres) + 1
             else
-                CGLSlai_struc(n)%latmax = 80
+                CGLSlai_struc(n)%latmax = 80.
                 CGLSlai_struc(n)%latmin = -59.9910714285396
-                CGLSlai_struc(n)%lonmax= -180
+                CGLSlai_struc(n)%lonmax= -180.
                 CGLSlai_struc(n)%lonmin = 179.991071429063
                 CGLSlai_struc(n)%dlat = 0.008928002004371148
                 CGLSlai_struc(n)%dlon = 0.008928349985839856

--- a/lis/dataassim/obs/CGLS_LAI/CGLSlai_Mod.F90
+++ b/lis/dataassim/obs/CGLS_LAI/CGLSlai_Mod.F90
@@ -242,28 +242,42 @@ contains
 
         do n=1,LIS_rc%nnest
             if (CGLSlai_struc(n)%isresampled.ne.0) then
-                CGLSlai_struc(n)%latmax = 90 - 0.5 * CGLSlai_struc(n)%spatialres
-                CGLSlai_struc(n)%latmin = -90 + 0.5 * CGLSlai_struc(n)%spatialres
-                CGLSlai_struc(n)%lonmax = 180 - 0.5 * CGLSlai_struc(n)%spatialres
-                CGLSlai_struc(n)%lonmin = -180 + 0.5 * CGLSlai_struc(n)%spatialres
-                CGLSlai_struc(n)%dlat = CGLSlai_struc(n)%spatialres
-                CGLSlai_struc(n)%dlon = CGLSlai_struc(n)%spatialres
                 call ESMF_ConfigFindLabel(LIS_config,"CGLS LAI lat max:",&
                      rc=status)
-                call ESMF_ConfigGetAttribute(LIS_config,CGLSlai_struc(n)%latmax,&
-                     rc=status)
+                if (status .ne. 0) then
+                    CGLSlai_struc(n)%latmax = 90 - 0.5 * CGLSlai_struc(n)%spatialres
+                else
+                    call ESMF_ConfigGetAttribute(LIS_config,CGLSlai_struc(n)%latmax,&
+                         rc=status)
+                endif
+
                 call ESMF_ConfigFindLabel(LIS_config,"CGLS LAI lat min:",&
                      rc=status)
-                call ESMF_ConfigGetAttribute(LIS_config,CGLSlai_struc(n)%latmin,&
-                     rc=status)
+                if (status .ne. 0) then
+                    CGLSlai_struc(n)%latmin = -90 + 0.5 * CGLSlai_struc(n)%spatialres
+                else
+                    call ESMF_ConfigGetAttribute(LIS_config,CGLSlai_struc(n)%latmin,&
+                         rc=status)
+                endif
                 call ESMF_ConfigFindLabel(LIS_config,"CGLS LAI lon max:",&
                      rc=status)
-                call ESMF_ConfigGetAttribute(LIS_config,CGLSlai_struc(n)%lonmax,&
-                     rc=status)
+                if (status .ne. 0) then
+                    CGLSlai_struc(n)%lonmax = 180 - 0.5 * CGLSlai_struc(n)%spatialres
+                else
+                    call ESMF_ConfigGetAttribute(LIS_config,CGLSlai_struc(n)%lonmax,&
+                         rc=status)
+                endif
                 call ESMF_ConfigFindLabel(LIS_config,"CGLS LAI lon min:",&
                      rc=status)
-                call ESMF_ConfigGetAttribute(LIS_config,CGLSlai_struc(n)%lonmin,&
-                     rc=status)
+                if (status .ne. 0) then
+                    CGLSlai_struc(n)%lonmin = -180 + 0.5 * CGLSlai_struc(n)%spatialres
+                else
+                    call ESMF_ConfigGetAttribute(LIS_config,CGLSlai_struc(n)%lonmin,&
+                         rc=status)
+                endif
+
+                CGLSlai_struc(n)%dlat = CGLSlai_struc(n)%spatialres
+                CGLSlai_struc(n)%dlon = CGLSlai_struc(n)%spatialres
                 CGLSlai_struc(n)%nr = nint((CGLSlai_struc(n)%latmax - CGLSlai_struc(n)%latmin)&
                                            / CGLSlai_struc(n)%spatialres) + 1
                 CGLSlai_struc(n)%nc = nint((CGLSlai_struc(n)%lonmax - CGLSlai_struc(n)%lonmin)&

--- a/lis/interp/map_utils.F90
+++ b/lis/interp/map_utils.F90
@@ -681,6 +681,7 @@ CONTAINS
       slon360 = proj%lon1
     ENDIF
     deltalon = lon360 - slon360
+    IF (deltalon .LT. 0) deltalon = deltalon + 360.
 
     ! Compute i/j
     i = deltalon/proj%dlon + 1.

--- a/lis/interp/map_utils.F90
+++ b/lis/interp/map_utils.F90
@@ -1157,6 +1157,7 @@ CONTAINS
        slon360 = proj%lon1
     ENDIF
     deltalon = lon360 - slon360
+    IF (deltalon .LT. 0) deltalon = deltalon + 360.     
 
     ! Compute i/j
     i = deltalon/proj%dlon + 1.


### PR DESCRIPTION
Bug 1: Incorrect specification of observation domain in CGLS LAI reader if using global files without specifying extents
Bug 2: missing check for negative `deltalon` in map_utils.f90

@mbechtold 