### PR TITLE
ENH: additional options for soil moisture DA

### DIFF
--- a/lis/configs/lis.config.adoc
+++ b/lis/configs/lis.config.adoc
@@ -8163,6 +8163,14 @@ the _lis.config_ file, the default value of 2000.0 mm is used.
 This maximum only applies to tiles identified as glacier in the
 landcover classification.
 
+`Noah-MP.4.0.1 apply soil moisture observation QC:` specifies whether
+quality control should reject observations which are too close to the
+tails. Defaults to `.true.`.
+
+`Noah-MP.4.0.1 apply soil moisture DA over forests:` specifies whether
+soil moisture data assimilaion may be performed over forests. Defaults
+to `.false.`.
+
 .Example _lis.config_ entry
 ....
 Noah-MP.4.0.1 model timestep:                15mn
@@ -8204,6 +8212,8 @@ Noah-MP.4.0.1 initial water table depth:                    2.5
 Noah-MP.4.0.1 initial water in the aquifer:                 4900.0
 Noah-MP.4.0.1 initial water in aquifer and saturated soil:  4900.0
 Noah-MP.4.0.1 snow depth glacier model option:              2000
+Noah-MP.4.0.1 apply soil moisture observation QC:           .true.
+Noah-MP.4.0.1 apply soil moisture DA over forests:          .false.
 ....
 
 

--- a/lis/configs/lis.config.adoc
+++ b/lis/configs/lis.config.adoc
@@ -2838,6 +2838,33 @@ deviation.
 `ESA CCI soil moisture number of bins in the CDF:` specifies the number of
 bins in the CDF.
 
+`ESA CCI CDF read option:` specifies whether to read all months of
+or to read month by month from a monthly CDF file.
+
+Acceptable values are:
+
+|====
+|Value    | Description
+
+|0 | Read all months
+|1 | Read month by month
+|====
+
+NOTE: Select 0 for yearly CDF data.
+
+`ESA CCI soil moisture assimilate at 0UTC:` specifies whether to assimilate at 00:00 UTC
+or at local noon.
+
+Acceptable values are:
+
+|====
+|Value    | Description
+
+|.true. | Assimilate at 00:00 UTC
+|.false. | Assimilate at local noon
+|====
+
+
 .Example _lis.config_ entry
 ....
 ESA CCI soil moisture data directory:

--- a/lis/configs/lis.config.adoc
+++ b/lis/configs/lis.config.adoc
@@ -2838,7 +2838,7 @@ deviation.
 `ESA CCI soil moisture number of bins in the CDF:` specifies the number of
 bins in the CDF.
 
-`ESA CCI CDF read option:` specifies whether to read all months of
+`ESA CCI CDF read option:` specifies whether to read all months at once
 or to read month by month from a monthly CDF file.
 
 Acceptable values are:
@@ -2874,6 +2874,9 @@ ESA CCI use scaled standard deviation model:
 ESA CCI model CDF file:
 ESA CCI observation CDF file:
 ESA CCI soil moisture number of bins in the CDF:
+ESA CCI CDF read option:
+ESA CCI soil moisture assimilate at 0UTC:
+
 ....
 
 

--- a/lis/configs/lis.config.adoc
+++ b/lis/configs/lis.config.adoc
@@ -8165,7 +8165,7 @@ landcover classification.
 
 `Noah-MP.4.0.1 apply soil moisture observation QC:` specifies whether
 quality control should reject observations which are too close to the
-tails. Defaults to `.true.`.
+soil moisture boundaries. Defaults to `.true.`.
 
 `Noah-MP.4.0.1 apply soil moisture DA over forests:` specifies whether
 soil moisture data assimilaion may be performed over forests. Defaults

--- a/lis/configs/lis.config.adoc
+++ b/lis/configs/lis.config.adoc
@@ -2853,7 +2853,7 @@ Acceptable values are:
 NOTE: Select 0 for yearly CDF data.
 
 `ESA CCI soil moisture assimilate at 0UTC:` specifies whether to assimilate at 00:00 UTC
-or at local noon.
+or at local noon (note that ESA CCI retrievals are centered around 00:00 UTC).
 
 Acceptable values are:
 

--- a/lis/dataassim/obs/ESACCI_sm/ESACCI_sm_Mod.F90
+++ b/lis/dataassim/obs/ESACCI_sm/ESACCI_sm_Mod.F90
@@ -50,6 +50,8 @@
 !   
 ! !REVISION HISTORY: 
 !  01 Oct 2012: Sujay Kumar, Initial Specification
+!  22 Dec 2021: Zdenko Heyvaert, Updated for reading monthly CDF for the current month
+!  03 Nov 2022: Zdenko Heyvaert, Added option to assimilate at 00:00 UTC
 ! 
 module ESACCI_sm_Mod
 ! !USES: 
@@ -99,6 +101,13 @@ module ESACCI_sm_Mod
 
      integer                :: nbins
      integer                :: ntimes
+     logical                :: cdf_read_mon ! (ensures that we also read in the
+                                            !  data in the first simulated month)
+     integer                :: cdf_read_opt ! 0: read all months at one time
+                                            ! 1: read only the current month
+     character*100          :: modelcdffile
+     character*100          :: obscdffile
+     logical                :: midnight_assimilation
 
   end type ESACCI_sm_dec
   
@@ -161,8 +170,6 @@ contains
     real, pointer          ::  obs_temp(:,:)
     real, allocatable          :: xrange(:), cdf(:)
     real                   :: gridDesci(50)
-    character(len=LIS_CONST_PATH_LEN) :: modelcdffile(LIS_rc%nnest)
-    character(len=LIS_CONST_PATH_LEN) :: obscdffile(LIS_rc%nnest)
     real,      allocatable     :: ssdev(:)
 
     real, allocatable          ::  obserr(:,:)
@@ -225,7 +232,7 @@ contains
          rc=status)
     do n=1,LIS_rc%nnest
        if(LIS_rc%dascaloption(k).ne."none") then 
-          call ESMF_ConfigGetAttribute(LIS_config,modelcdffile(n),rc=status)
+          call ESMF_ConfigGetAttribute(LIS_config,ESACCI_sm_struc(n)%modelcdffile,rc=status)
           call LIS_verify(status, 'ESA CCI model CDF file: not defined')
        endif
     enddo
@@ -234,7 +241,7 @@ contains
          rc=status)
     do n=1,LIS_rc%nnest
        if(LIS_rc%dascaloption(k).ne."none") then 
-          call ESMF_ConfigGetAttribute(LIS_config,obscdffile(n),rc=status)
+          call ESMF_ConfigGetAttribute(LIS_config,ESACCI_sm_struc(n)%obscdffile,rc=status)
           call LIS_verify(status, 'ESA CCI observation CDF file: not defined')
        endif
     enddo
@@ -246,6 +253,22 @@ contains
           call LIS_verify(status, "ESA CCI soil moisture number of bins in the CDF: not defined")
        endif
     enddo
+
+   do n=1,LIS_rc%nnest
+     ESACCI_sm_struc(n)%cdf_read_mon = .false.
+
+     call ESMF_ConfigFindLabel(LIS_config, "ESA CCI CDF read option:", rc=status) ! 0: read CDF for all months/year
+                                                                                  ! 1: read CDF for current month
+     call ESMF_ConfigGetAttribute(LIS_config, ESACCI_sm_struc(n)%cdf_read_opt, rc=status)
+     call LIS_verify(status, "ESA CCI CDF read option: not defined")
+   enddo
+
+   ! ZH: assimilate at 0 UTC (if .true.) or local noon (the LIS default, if .false.)
+   call ESMF_ConfigFindLabel(LIS_config,"ESA CCI soil moisture assimilate at 0UTC:", rc=status)
+   do n=1,LIS_rc%nnest
+     call ESMF_ConfigGetAttribute(LIS_config, ESACCI_sm_struc(n)%midnight_assimilation, rc=status)
+     call LIS_verify(status, 'ESA CCI soil moisture assimilate at 0UTC: is missing')
+   enddo
 
    do n=1,LIS_rc%nnest
        call ESMF_AttributeSet(OBS_State(n),"Data Update Status",&
@@ -387,92 +410,113 @@ contains
     enddo
     
     do n=1,LIS_rc%nnest
-       if(LIS_rc%dascaloption(k).ne."none") then 
+       allocate(ssdev(LIS_rc%obs_ngrid(k)))
+       ssdev = obs_pert%ssdev(1)  
 
-          call LIS_getCDFattributes(k,modelcdffile(n),&
+       if(trim(LIS_rc%dascaloption(k)).eq."CDF matching") then
+
+          call LIS_getCDFattributes(k,ESACCI_sm_struc(n)%modelcdffile,&
                ESACCI_sm_struc(n)%ntimes, ngrid)
 
-          allocate(ssdev(LIS_rc%obs_ngrid(k)))
-          ssdev = obs_pert%ssdev(1)
-
-          allocate(ESACCI_sm_struc(n)%model_mu(LIS_rc%obs_ngrid(k),&
-               ESACCI_sm_struc(n)%ntimes))
-          allocate(ESACCI_sm_struc(n)%model_sigma(LIS_rc%obs_ngrid(k),&
-               ESACCI_sm_struc(n)%ntimes))
-          allocate(ESACCI_sm_struc(n)%obs_mu(LIS_rc%obs_ngrid(k),&
-               ESACCI_sm_struc(n)%ntimes))
-          allocate(ESACCI_sm_struc(n)%obs_sigma(LIS_rc%obs_ngrid(k),&
-               ESACCI_sm_struc(n)%ntimes))
-          allocate(ESACCI_sm_struc(n)%model_xrange(&
-               LIS_rc%obs_ngrid(k), ESACCI_sm_struc(n)%ntimes, &
-               ESACCI_sm_struc(n)%nbins))
-          allocate(ESACCI_sm_struc(n)%obs_xrange(&
-               LIS_rc%obs_ngrid(k), ESACCI_sm_struc(n)%ntimes, &
-               ESACCI_sm_struc(n)%nbins))
-          allocate(ESACCI_sm_struc(n)%model_cdf(&
-               LIS_rc%obs_ngrid(k), ESACCI_sm_struc(n)%ntimes, &
-               ESACCI_sm_struc(n)%nbins))
-          allocate(ESACCI_sm_struc(n)%obs_cdf(&
-               LIS_rc%obs_ngrid(k), ESACCI_sm_struc(n)%ntimes, & 
-               ESACCI_sm_struc(n)%nbins))
+          if (ESACCI_sm_struc(n)%cdf_read_opt.eq.0) then
+               allocate(ESACCI_sm_struc(n)%model_mu(LIS_rc%obs_ngrid(k),&
+                    ESACCI_sm_struc(n)%ntimes))
+               allocate(ESACCI_sm_struc(n)%model_sigma(LIS_rc%obs_ngrid(k),&
+                    ESACCI_sm_struc(n)%ntimes))
+               allocate(ESACCI_sm_struc(n)%obs_mu(LIS_rc%obs_ngrid(k),&
+                    ESACCI_sm_struc(n)%ntimes))
+               allocate(ESACCI_sm_struc(n)%obs_sigma(LIS_rc%obs_ngrid(k),&
+                    ESACCI_sm_struc(n)%ntimes))
+               allocate(ESACCI_sm_struc(n)%model_xrange(&
+                    LIS_rc%obs_ngrid(k), ESACCI_sm_struc(n)%ntimes, &
+                    ESACCI_sm_struc(n)%nbins))
+               allocate(ESACCI_sm_struc(n)%obs_xrange(&
+                    LIS_rc%obs_ngrid(k), ESACCI_sm_struc(n)%ntimes, &
+                    ESACCI_sm_struc(n)%nbins))
+               allocate(ESACCI_sm_struc(n)%model_cdf(&
+                    LIS_rc%obs_ngrid(k), ESACCI_sm_struc(n)%ntimes, &
+                    ESACCI_sm_struc(n)%nbins))
+               allocate(ESACCI_sm_struc(n)%obs_cdf(&
+                    LIS_rc%obs_ngrid(k), ESACCI_sm_struc(n)%ntimes, & 
+                    ESACCI_sm_struc(n)%nbins))
+          else
+               allocate(ESACCI_sm_struc(n)%model_mu(LIS_rc%obs_ngrid(k),1))
+               allocate(ESACCI_sm_struc(n)%model_sigma(LIS_rc%obs_ngrid(k),1))
+               allocate(ESACCI_sm_struc(n)%obs_mu(LIS_rc%obs_ngrid(k),1))
+               allocate(ESACCI_sm_struc(n)%obs_sigma(LIS_rc%obs_ngrid(k),1))
+               allocate(ESACCI_sm_struc(n)%model_xrange(&
+                    LIS_rc%obs_ngrid(k), 1, &
+                    ESACCI_sm_struc(n)%nbins))
+               allocate(ESACCI_sm_struc(n)%obs_xrange(&
+                    LIS_rc%obs_ngrid(k), 1, &
+                    ESACCI_sm_struc(n)%nbins))
+               allocate(ESACCI_sm_struc(n)%model_cdf(&
+                    LIS_rc%obs_ngrid(k), 1, &
+                    ESACCI_sm_struc(n)%nbins))
+               allocate(ESACCI_sm_struc(n)%obs_cdf(&
+                    LIS_rc%obs_ngrid(k), 1, & 
+                    ESACCI_sm_struc(n)%nbins))
+          endif
 
 !----------------------------------------------------------------------------
 ! Read the model and observation CDF data
+! Only if not monthly: otherwise this is done in the read_ESACCIsm module
 !----------------------------------------------------------------------------
-          call LIS_readMeanSigmaData(n,k,&
-               ESACCI_sm_struc(n)%ntimes, & 
-               LIS_rc%obs_ngrid(k), &
-               modelcdffile(n), &
-               "SoilMoist",&
-               ESACCI_sm_struc(n)%model_mu,&
-               ESACCI_sm_struc(n)%model_sigma)
+          if (ESACCI_sm_struc(n)%cdf_read_opt.eq.0) then
+               call LIS_readMeanSigmaData(n,k,&
+                    ESACCI_sm_struc(n)%ntimes, & 
+                    LIS_rc%obs_ngrid(k), &
+                    ESACCI_sm_struc(n)%modelcdffile, &
+                    "SoilMoist",&
+                    ESACCI_sm_struc(n)%model_mu,&
+                    ESACCI_sm_struc(n)%model_sigma)
 
-          call LIS_readMeanSigmaData(n,k,&
-               ESACCI_sm_struc(n)%ntimes, & 
-               LIS_rc%obs_ngrid(k), &
-               obscdffile(n), &
-               "SoilMoist",&
-               ESACCI_sm_struc(n)%obs_mu,&
-               ESACCI_sm_struc(n)%obs_sigma)
+               call LIS_readMeanSigmaData(n,k,&
+                    ESACCI_sm_struc(n)%ntimes, & 
+                    LIS_rc%obs_ngrid(k), &
+                    ESACCI_sm_struc(n)%obscdffile, &
+                    "SoilMoist",&
+                    ESACCI_sm_struc(n)%obs_mu,&
+                    ESACCI_sm_struc(n)%obs_sigma)
 
-          call LIS_readCDFdata(n,k,&
-               ESACCI_sm_struc(n)%nbins,&
-               ESACCI_sm_struc(n)%ntimes, & 
-               LIS_rc%obs_ngrid(k), &
-               modelcdffile(n), &
-               "SoilMoist",&
-               ESACCI_sm_struc(n)%model_xrange,&
-               ESACCI_sm_struc(n)%model_cdf)
+               call LIS_readCDFdata(n,k,&
+                    ESACCI_sm_struc(n)%nbins,&
+                    ESACCI_sm_struc(n)%ntimes, & 
+                    LIS_rc%obs_ngrid(k), &
+                    ESACCI_sm_struc(n)%modelcdffile, &
+                    "SoilMoist",&
+                    ESACCI_sm_struc(n)%model_xrange,&
+                    ESACCI_sm_struc(n)%model_cdf)
 
-          call LIS_readCDFdata(n,k,&
-               ESACCI_sm_struc(n)%nbins,&
-               ESACCI_sm_struc(n)%ntimes, & 
-               LIS_rc%obs_ngrid(k), &
-               obscdffile(n), &
-               "SoilMoist",&
-               ESACCI_sm_struc(n)%obs_xrange,&
-               ESACCI_sm_struc(n)%obs_cdf)
+               call LIS_readCDFdata(n,k,&
+                    ESACCI_sm_struc(n)%nbins,&
+                    ESACCI_sm_struc(n)%ntimes, & 
+                    LIS_rc%obs_ngrid(k), &
+                    ESACCI_sm_struc(n)%obscdffile, &
+                    "SoilMoist",&
+                    ESACCI_sm_struc(n)%obs_xrange,&
+                    ESACCI_sm_struc(n)%obs_cdf)
 
-          if(ESACCI_sm_struc(n)%useSsdevScal.eq.1) then 
-             if(ESACCI_sm_struc(n)%ntimes.eq.1) then 
-                jj = 1
-             else
-                jj = LIS_rc%mo
-             endif
-             do t=1,LIS_rc%obs_ngrid(k)
-                if(ESACCI_sm_struc(n)%obs_sigma(t,jj).ne.LIS_rc%udef) then 
-                   print*, ssdev(t),ESACCI_sm_struc(n)%model_sigma(t,jj),&
-                        ESACCI_sm_struc(n)%obs_sigma(t,jj)
-                   if(ESACCI_sm_struc(n)%obs_sigma(t,jj).ne.0) then 
-                   ssdev(t) = ssdev(t)*ESACCI_sm_struc(n)%model_sigma(t,jj)/&
-                        ESACCI_sm_struc(n)%obs_sigma(t,jj)
-                   endif
-                      
-                   if(ssdev(t).lt.minssdev) then 
-                      ssdev(t) = minssdev
-                   endif
-                endif
-             enddo
+               if(ESACCI_sm_struc(n)%useSsdevScal.eq.1) then 
+                    if(ESACCI_sm_struc(n)%ntimes.eq.1) then 
+                         jj = 1
+                    else
+                         jj = LIS_rc%mo
+                    endif
+                    do t=1,LIS_rc%obs_ngrid(k)
+                         if(ESACCI_sm_struc(n)%obs_sigma(t,jj).ne.LIS_rc%udef) then 
+                              print*, ssdev(t),ESACCI_sm_struc(n)%model_sigma(t,jj),&
+                              ESACCI_sm_struc(n)%obs_sigma(t,jj)
+                              if(ESACCI_sm_struc(n)%obs_sigma(t,jj).ne.0) then 
+                                   ssdev(t) = ssdev(t)*ESACCI_sm_struc(n)%model_sigma(t,jj)/&
+                                   ESACCI_sm_struc(n)%obs_sigma(t,jj)
+                              endif
+                              if(ssdev(t).lt.minssdev) then 
+                                   ssdev(t) = minssdev
+                              endif
+                         endif
+                    enddo
+               endif
           endif
 
 #if 0           
@@ -515,10 +559,8 @@ contains
                   ssdev,itemCount=LIS_rc%obs_ngrid(k),rc=status)
              call LIS_verify(status)
           endif
-
-          deallocate(ssdev)
-
        endif
+       deallocate(ssdev)
     enddo
 
     do n=1,LIS_rc%nnest

--- a/lis/dataassim/obs/ESACCI_sm/read_ESACCIsm.F90
+++ b/lis/dataassim/obs/ESACCI_sm/read_ESACCIsm.F90
@@ -15,6 +15,8 @@
 ! !REVISION HISTORY:
 !  01 Oct 2012: Sujay Kumar, Initial Specification
 !  13 Jul 2016: Sujay Kumar, Updated the code to support DA in observation space
+!  22 Dec 2021: Zdenko Heyvaert, Updated for reading monthly CDF for the current month
+!  03 Nov 2022: Zdenko Heyvaert, Added option to assimilate at 00:00 UTC
 !
 ! !INTERFACE: 
 subroutine read_ESACCIsm(n,k,  OBS_State, OBS_Pert_State)
@@ -159,8 +161,13 @@ subroutine read_ESACCIsm(n,k,  OBS_State, OBS_Pert_State)
      do c=1,LIS_rc%obs_lnc(k)
         if(LIS_obs_domain(n,k)%gindex(c,r).ne.-1) then 
            grid_index = c+(r-1)*LIS_rc%obs_lnc(k)
+           
+           if(ESACCI_sm_struc(n)%midnight_assimilation.eq..true.) then
+              dt = (LIS_rc%gmt)*3600.0 ! assimilate at 0 UTC
+           else
+              dt = (LIS_rc%gmt - ESACCI_sm_struc(n)%smtime(c,r))*3600.0 ! assimilate at local noon
+           endif
 
-           dt = (LIS_rc%gmt - ESACCI_sm_struc(n)%smtime(c,r))*3600.0
            if(dt.ge.0.and.dt.lt.LIS_rc%ts) then 
               sm_current(c,r) = & 
                    ESACCI_sm_struc(n)%smobs(c,r)
@@ -179,18 +186,78 @@ subroutine read_ESACCIsm(n,k,  OBS_State, OBS_Pert_State)
 !-------------------------------------------------------------------------
 !  Transform data to the LSM climatology using a CDF-scaling approach
 !-------------------------------------------------------------------------     
-  if(LIS_rc%dascaloption(k).ne."none".and.fnd.ne.0) then  
-     call LIS_rescale_with_CDF_matching(    &
-          n,k,                              & 
-          ESACCI_sm_struc(n)%nbins,         & 
-          ESACCI_sm_struc(n)%ntimes,        & 
-          MAX_SM_VALUE,                     & 
-          MIN_SM_VALUE,                     & 
-          ESACCI_sm_struc(n)%model_xrange,  &
-          ESACCI_sm_struc(n)%obs_xrange,    &
-          ESACCI_sm_struc(n)%model_cdf,     &
-          ESACCI_sm_struc(n)%obs_cdf,       &
-          sm_current)
+  if (ESACCI_sm_struc(n)%ntimes.gt.1.and.ESACCI_sm_struc(n)%cdf_read_opt.eq.1) then
+   if (.not. ESACCI_sm_struc(n)%cdf_read_mon.or.LIS_rc%da.eq.1.and.LIS_rc%hr.eq.0.and.LIS_rc%mn.eq.0.and.LIS_rc%ss.eq.0) then
+
+      call LIS_readMeanSigmaData(n,k,&
+            ESACCI_sm_struc(n)%ntimes, & 
+            LIS_rc%obs_ngrid(k), &
+            ESACCI_sm_struc(n)%modelcdffile, &
+            "SoilMoist",&
+            ESACCI_sm_struc(n)%model_mu,&
+            ESACCI_sm_struc(n)%model_sigma,&
+            LIS_rc%mo)
+
+      call LIS_readMeanSigmaData(n,k,&
+            ESACCI_sm_struc(n)%ntimes, & 
+            LIS_rc%obs_ngrid(k), &
+            ESACCI_sm_struc(n)%obscdffile, &
+            "SoilMoist",&
+            ESACCI_sm_struc(n)%obs_mu,&
+            ESACCI_sm_struc(n)%obs_sigma,&
+            LIS_rc%mo)
+
+      call LIS_readCDFdata(n,k,&
+            ESACCI_sm_struc(n)%nbins,&
+            ESACCI_sm_struc(n)%ntimes, & 
+            LIS_rc%obs_ngrid(k), &
+            ESACCI_sm_struc(n)%modelcdffile, &
+            "SoilMoist",&
+            ESACCI_sm_struc(n)%model_xrange,&
+            ESACCI_sm_struc(n)%model_cdf,&
+            LIS_rc%mo)
+
+      call LIS_readCDFdata(n,k,&
+            ESACCI_sm_struc(n)%nbins,&
+            ESACCI_sm_struc(n)%ntimes, & 
+            LIS_rc%obs_ngrid(k), &
+            ESACCI_sm_struc(n)%obscdffile, &
+            "SoilMoist",&
+            ESACCI_sm_struc(n)%obs_xrange,&
+            ESACCI_sm_struc(n)%obs_cdf,&
+            LIS_rc%mo)
+
+      ESACCI_sm_struc(n)%cdf_read_mon = .true.
+   endif
+  endif
+
+
+  if(trim(LIS_rc%dascaloption(k)).eq."CDF matching".and.fnd.ne.0) then  
+   if (ESACCI_sm_struc(n)%ntimes.gt.1.and.ESACCI_sm_struc(n)%cdf_read_opt.eq.1) then
+      call LIS_rescale_with_CDF_matching(    &
+           n,k,                              & 
+           ESACCI_sm_struc(n)%nbins,         & 
+           1,                                & 
+           MAX_SM_VALUE,                     & 
+           MIN_SM_VALUE,                     & 
+           ESACCI_sm_struc(n)%model_xrange,  &
+           ESACCI_sm_struc(n)%obs_xrange,    &
+           ESACCI_sm_struc(n)%model_cdf,     &
+           ESACCI_sm_struc(n)%obs_cdf,       &
+           sm_current)
+   else
+      call LIS_rescale_with_CDF_matching(    &
+           n,k,                              & 
+           ESACCI_sm_struc(n)%nbins,         & 
+           ESACCI_sm_struc(n)%ntimes,        & 
+           MAX_SM_VALUE,                     & 
+           MIN_SM_VALUE,                     & 
+           ESACCI_sm_struc(n)%model_xrange,  &
+           ESACCI_sm_struc(n)%obs_xrange,    &
+           ESACCI_sm_struc(n)%model_cdf,     &
+           ESACCI_sm_struc(n)%obs_cdf,       &
+           sm_current)
+   endif
   endif
 
   obsl = LIS_rc%udef 
@@ -266,7 +333,9 @@ subroutine read_ESACCIsm(n,k,  OBS_State, OBS_Pert_State)
 
         allocate(ssdev(LIS_rc%obs_ngrid(k)))
         ssdev = ESACCI_sm_struc(n)%ssdev_inp
-        if(ESACCI_sm_struc(n)%ntimes.eq.1) then 
+        if(ESACCI_sm_struc(n)%cdf_read_opt .eq. 1) then
+           jj = 1
+        else if(ESACCI_sm_struc(n)%ntimes.eq.1) then 
            jj = 1
         else
            jj = LIS_rc%mo

--- a/lis/dataassim/obs/ESACCI_sm/read_ESACCIsm.F90
+++ b/lis/dataassim/obs/ESACCI_sm/read_ESACCIsm.F90
@@ -165,6 +165,7 @@ subroutine read_ESACCIsm(n,k,  OBS_State, OBS_Pert_State)
            if(ESACCI_sm_struc(n)%midnight_assimilation.eq..true.) then
               dt = (LIS_rc%gmt)*3600.0 ! assimilate at 0 UTC
            else
+              ! smtime: local noon (based on longitude) transformed to GMT time zone
               dt = (LIS_rc%gmt - ESACCI_sm_struc(n)%smtime(c,r))*3600.0 ! assimilate at local noon
            endif
 

--- a/lis/surfacemodels/land/noahmp.4.0.1/NoahMP401_lsmMod.F90
+++ b/lis/surfacemodels/land/noahmp.4.0.1/NoahMP401_lsmMod.F90
@@ -210,6 +210,8 @@ module NoahMP401_lsmMod
         integer            :: pedo_opt
         integer            :: crop_opt
         integer            :: urban_opt
+        logical            :: QC_opt
+        logical            :: forestDA_opt
         type(NoahMP401dec), pointer :: noahmp401(:)
     end type NoahMP401_type_dec
 

--- a/lis/surfacemodels/land/noahmp.4.0.1/NoahMP401_readcrd.F90
+++ b/lis/surfacemodels/land/noahmp.4.0.1/NoahMP401_readcrd.F90
@@ -397,7 +397,7 @@ subroutine NoahMP401_readcrd()
                               NOAHMP401_struc(n)%urban_opt
     enddo
 
-    ! ZH: remove QC relating to the tails of soil moisture distributions; 
+    ! ZH: not applying the recommended QC to avoid out of bounds soil moisture;
     ! can be useful when performing a run excluding the increment updates (e.g., before CDF matching)
     call ESMF_ConfigFindLabel(LIS_config, &
          "Noah-MP.4.0.1 apply soil moisture observation QC:", rc=rc)
@@ -408,7 +408,7 @@ subroutine NoahMP401_readcrd()
                               NOAHMP401_struc(n)%QC_opt
     enddo
 
-    ! ZH: option to assimilate soil moisture over forests
+    ! ZH: option to allow assimilation of soil moisture over forests
     call ESMF_ConfigFindLabel(LIS_config, &
          "Noah-MP.4.0.1 apply soil moisture DA over forests:", rc=rc)
     do n=1, LIS_rc%nnest

--- a/lis/surfacemodels/land/noahmp.4.0.1/NoahMP401_readcrd.F90
+++ b/lis/surfacemodels/land/noahmp.4.0.1/NoahMP401_readcrd.F90
@@ -397,6 +397,29 @@ subroutine NoahMP401_readcrd()
                               NOAHMP401_struc(n)%urban_opt
     enddo
 
+    ! ZH: remove QC relating to the tails of soil moisture distributions; 
+    ! can be useful when performing a run excluding the increment updates (e.g., before CDF matching)
+    call ESMF_ConfigFindLabel(LIS_config, &
+         "Noah-MP.4.0.1 apply soil moisture observation QC:", rc=rc)
+    do n=1, LIS_rc%nnest
+        call ESMF_ConfigGetAttribute(LIS_config, NOAHMP401_struc(n)%QC_opt, &
+             default=.true., rc=rc)
+        write(LIS_logunit,33) "applying QC:", &
+                              NOAHMP401_struc(n)%QC_opt
+    enddo
+
+    ! ZH: option to assimilate soil moisture over forests
+    call ESMF_ConfigFindLabel(LIS_config, &
+         "Noah-MP.4.0.1 apply soil moisture DA over forests:", rc=rc)
+    do n=1, LIS_rc%nnest
+        call ESMF_ConfigGetAttribute(LIS_config, NOAHMP401_struc(n)%forestDA_opt, &
+             default=.false., rc=rc)
+        write(LIS_logunit,33) "soil moisture DA over forests:", &
+                              NOAHMP401_struc(n)%forestDA_opt
+    enddo
+
+
+
     ! The following lines hard code the LDT NetCDF variable names. 
     ! Modified by Zhuo Wang on 11/08/2018
     ! Setting some values to PLANTING, HARVEST, SEASON_GDD, SOILCOMP, SOILCL1-->SOILCL4 in NoahMP401_main.F90

--- a/lis/surfacemodels/land/noahmp.4.0.1/da_soilm/noahmp401_qc_soilmobs.F90
+++ b/lis/surfacemodels/land/noahmp.4.0.1/da_soilm/noahmp401_qc_soilmobs.F90
@@ -253,7 +253,7 @@ subroutine NoahMP401_qc_soilmobs(n,k,OBS_State)
            smobs(t) = LIS_rc%udef 
         elseif(t1_obs(t).le.LIS_CONST_TKFRZ) then ! Var name Noah36 --> t1
            smobs(t) = LIS_rc%udef
-        elseif(vegt_obs(t).le.4) then !forest types ! Var name Noah36 --> vegt
+        elseif((vegt_obs(t).le.4).and.(NOAHMP401_struc(n)%forestDA_opt.eq..false.)) then !forest types ! Var name Noah36 --> vegt
            smobs(t) = LIS_rc%udef
  ! MN: check for snow  
         elseif(sneqv_obs(t).gt.0.001) then 
@@ -267,10 +267,12 @@ subroutine NoahMP401_qc_soilmobs(n,k,OBS_State)
                                            ! while Noah3.9 uses monthly climatological greenness. 
            smobs(t) = LIS_rc%udef        
 !too close to the tails, could be due to scaling, so reject. 
-        elseif(smcmax_obs(t)-smobs(t).lt.0.02) then 
-           smobs(t) = LIS_rc%udef
-        elseif(smobs(t) - smcwlt_obs(t).lt.0.02) then 
-           smobs(t) = LIS_rc%udef
+        elseif(NOAHMP401_struc(n)%QC_opt.eq..true.) then
+            if(smcmax_obs(t)-smobs(t).lt.0.02) then 
+                 smobs(t) = LIS_rc%udef
+            elseif(smobs(t) - smcwlt_obs(t).lt.0.02) then 
+                 smobs(t) = LIS_rc%udef
+            endif
         endif
      endif
   enddo

--- a/lis/surfacemodels/land/noahmp.4.0.1/da_soilm/noahmp401_qc_soilmobs.F90
+++ b/lis/surfacemodels/land/noahmp.4.0.1/da_soilm/noahmp401_qc_soilmobs.F90
@@ -261,7 +261,8 @@ subroutine NoahMP401_qc_soilmobs(n,k,OBS_State)
         elseif(sca_obs(t).gt.0.0001) then  ! Var name sca 
            smobs(t) = LIS_rc%udef
  ! MN: check for green vegetation fraction NOTE: threshold incerased from 0.5 to 0.7 
-        elseif(shdfac_obs(t).gt.0.9) then  ! var name Noah36 shdfac 12-month green veg. frac.  
+        elseif((shdfac_obs(t).gt.0.9).and.(NOAHMP401_struc(n)%forestDA_opt.eq..false.)) then  
+                                           ! var name Noah36 shdfac 12-month green veg. frac.  
                                            ! The threshold has been tuned for spatial coverage
                                            ! Higher than Noah.3.9 because max greenness is used for shdfac in Noah-MP.4.0.1
                                            ! while Noah3.9 uses monthly climatological greenness. 


### PR DESCRIPTION
### Description

* ESA CCI SM data assimilation:
  *  Added the option to assimilate at 00:00 UTC instead of local noon
  *  Added support for monthly CDF matching
 
 * Noah-MP 4.0.1 soil moisture data assimilation:
   * Added the option to assimilate over forests (`.false.` by default)
   * Added QC checks of soil moisture tails as an *option* (`.true.` by default)

