### PR TITLE
BUG: catching another stripe issue related the 0W longitude due to rounding issues

### DIFF
--- a/lis/interp/map_utils.F90
+++ b/lis/interp/map_utils.F90
@@ -681,7 +681,8 @@ CONTAINS
       slon360 = proj%lon1
     ENDIF
     deltalon = lon360 - slon360
-    IF (deltalon .LT. 0) deltalon = deltalon + 360.
+    ! MB: only + 360 when rounding of deltalon/proj%dlon + 1. does not give 1
+    IF (deltalon .LT. (-0.5*proj%dlon)) deltalon = deltalon + 360.
 
     ! Compute i/j
     i = deltalon/proj%dlon + 1.
@@ -1158,7 +1159,8 @@ CONTAINS
        slon360 = proj%lon1
     ENDIF
     deltalon = lon360 - slon360
-    IF (deltalon .LT. 0) deltalon = deltalon + 360.     
+    ! MB: only + 360 when rounding of deltalon/proj%dlon + 1. does not give 1
+    IF (deltalon .LT. (-0.5*proj%dlon)) deltalon = deltalon + 360.     
 
     ! Compute i/j
     i = deltalon/proj%dlon + 1.


### PR DESCRIPTION
We encountered another dateline stripe issue for a new LIS grid with the resolution of the HWSD soil map.
The related line is improved. The change will not affect other grids with a lower number of non-zero digits for which this rounding issue did not occur.  Related #18