### PR TITLE
ENH: ESA CCI SM assimilation over barren ground

### DIFF
--- a/lis/configs/lis.config.adoc
+++ b/lis/configs/lis.config.adoc
@@ -2826,6 +2826,18 @@ moisture data.
 |"`combined`" | combined sensor type
 |===
 
+`ESA CCI soil moisture assimilate over barren grounds:` specifies whether to ignore the advisory flag for barren grounds
+in the ESA CCI product from v7.1 onwards
+
+Acceptable values are:
+
+|====
+|Value   | Description
+
+|.true.  | Assimilate over barren grounds
+|.false. | Don't assimilate over barren grounds
+|====
+
 `ESA CCI use scaled standard deviation model:` specifies if the observation
 error standard deviation is to be scaled using model and observation standard
 deviation.
@@ -2858,9 +2870,9 @@ or at local noon (note that ESA CCI retrievals are centered around 00:00 UTC).
 Acceptable values are:
 
 |====
-|Value    | Description
+|Value   | Description
 
-|.true. | Assimilate at 00:00 UTC
+|.true.  | Assimilate at 00:00 UTC
 |.false. | Assimilate at local noon
 |====
 
@@ -2869,7 +2881,8 @@ Acceptable values are:
 ....
 ESA CCI soil moisture data directory:
 ESA CCI soil moisture data version:
-ESA CCI soil moisture sensor type:            combined
+ESA CCI soil moisture sensor type:                    combined
+ESA CCI soil moisture assimilate over barren grounds:
 ESA CCI use scaled standard deviation model:
 ESA CCI model CDF file:
 ESA CCI observation CDF file:

--- a/lis/dataassim/obs/ESACCI_sm/ESACCI_sm_Mod.F90
+++ b/lis/dataassim/obs/ESACCI_sm/ESACCI_sm_Mod.F90
@@ -52,6 +52,7 @@
 !  01 Oct 2012: Sujay Kumar, Initial Specification
 !  22 Dec 2021: Zdenko Heyvaert, Updated for reading monthly CDF for the current month
 !  03 Nov 2022: Zdenko Heyvaert, Added option to assimilate at 00:00 UTC
+!  22 Nov 2022: Zdenko Heyvaert, Added option to ignore barren-grounds advisory flag (v7.1 onwards)
 ! 
 module ESACCI_sm_Mod
 ! !USES: 
@@ -108,6 +109,7 @@ module ESACCI_sm_Mod
      character*100          :: modelcdffile
      character*100          :: obscdffile
      logical                :: midnight_assimilation
+     logical                :: barren_assimilation
 
   end type ESACCI_sm_dec
   
@@ -268,6 +270,13 @@ contains
    do n=1,LIS_rc%nnest
      call ESMF_ConfigGetAttribute(LIS_config, ESACCI_sm_struc(n)%midnight_assimilation, rc=status)
      call LIS_verify(status, 'ESA CCI soil moisture assimilate at 0UTC: is missing')
+   enddo
+
+   ! ZH: from v7.1 onwards barren grounds received an advisory flag, hence they are not assimilated by default
+   call ESMF_ConfigFindLabel(LIS_config,"ESA CCI soil moisture assimilate over barren grounds:", rc=status)
+   do n=1,LIS_rc%nnest
+     call ESMF_ConfigGetAttribute(LIS_config, ESACCI_sm_struc(n)%barren_assimilation, rc=status)
+     call LIS_verify(status, 'ESA CCI soil moisture assimilate over barren grounds: is missing')
    enddo
 
    do n=1,LIS_rc%nnest


### PR DESCRIPTION
In ESA CCI SM v7.1, a new flag (64) was added to inform the users of passive retrievals over barren ground. The aim is to account for spurious effects introduced by subsurface scattering phenomena.

However, the data providers explicitly state that this flag is optional in both the PASSIVE and COMBINED products, i.e., the soil moisture has not been masked for barren grounds.

Because the reader only accounts for retrievals with a flag of 0, these observations are effectively masked for assimilation in LIS. To prevent this, a new option `ESA CCI soil moisture assimilate over barren grounds:` was added which, if set to `.true.`, enables assimilation of retrievals with flags equal to both 0 and 64.