### PR TITLE
BUG: adapted setting of the S1 obs domain

### DIFF
--- a/lis/dataassim/obs/S1_SNWD/S1_SNWD_Mod.F90
+++ b/lis/dataassim/obs/S1_SNWD/S1_SNWD_Mod.F90
@@ -93,8 +93,6 @@ contains
     type(ESMF_Field)       ::  pertField(LIS_rc%nnest)
     type(ESMF_ArraySpec)   ::  pertArrSpec
     character*100          ::  S1snowobsdir
-    character*80           ::  S1_firstfile
-    character*80           ::  S1_filename
     character*100          ::  temp
     real,  allocatable         ::  obsstd(:)
     character*1            ::  vid(2)
@@ -104,12 +102,6 @@ contains
     type(pert_dec_type)    :: obs_pert
     real, pointer          :: obs_temp(:,:)
     real, allocatable          :: ssdev(:)
-    real                   :: dx, dy
-    integer                :: NX, NY
-    integer                :: ncid
-    integer                :: flist
-    integer                :: ios
-    character*100          :: xname,yname
 
     allocate(S1_SNWD_struc(LIS_rc%nnest))
 
@@ -269,27 +261,16 @@ contains
 ! set up the S1 domain %and interpolation weights. 
 !-------------------------------------------------------------
 
- ! Open first file to get nx ny dimensions
-    call system('ls ./' // trim(S1snowobsdir) // ' > ./S1_listfiles.txt')
-
-    open(flist, file=trim('./S1_listfiles.txt'), &
-         status='old', iostat=status)
-
-    read(flist, '(a)', iostat=status) S1_firstfile
-    S1_filename = trim(S1snowobsdir) // '/' // trim(S1_firstfile)
-
-    ios = nf90_open(path=S1_filename,&
-                    mode=NF90_NOWRITE,ncid=ncid)
-    call LIS_verify(ios,&
-        'Error reading in S1 data dimensions: Error opening file '//S1_filename)
-    ios = nf90_inquire_dimension(ncid,1,yname,NY)
-    ios = nf90_inquire_dimension(ncid,2,xname,NX)
-    ios = nf90_close(ncid)
-
-
     do n=1,LIS_rc%nnest
-       S1_SNWD_struc(n)%nc = NY
-       S1_SNWD_struc(n)%nr = NX
+       call ESMF_ConfigFindLabel(LIS_config,&
+                     "S1 snow depth domain x-dimension size:",rc=status)
+       call ESMF_ConfigGetAttribute(LIS_config,S1_SNWD_struc(n)%nc,rc=status)
+       call LIS_verify(status,'[ERR] S1 snow depth domain x-dimension size: not defined')
+
+       call ESMF_ConfigFindLabel(LIS_config,&
+		             "S1 snow depth domain y-dimension size:",rc=status)
+       call ESMF_ConfigGetAttribute(LIS_config,S1_SNWD_struc(n)%nr,rc=status)
+       call LIS_verify(status,'[ERR] S1 snow depth domain y-dimension size: not defined')
 
        allocate(S1_SNWD_struc(n)%snwd(LIS_rc%obs_lnc(k),LIS_rc%obs_lnr(k)))
        allocate(S1_SNWD_struc(n)%snwdtime(&

--- a/lis/dataassim/obs/S1_sigmaVHSMLAI/S1_sigmaVHSMLAI_Mod.F90
+++ b/lis/dataassim/obs/S1_sigmaVHSMLAI/S1_sigmaVHSMLAI_Mod.F90
@@ -90,8 +90,6 @@ contains
     type(ESMF_Field)       ::  pertField(LIS_rc%nnest)
     type(ESMF_ArraySpec)   ::  pertArrSpec
     character*100          ::  S1sigmaobsdir
-    character*80           ::  S1_firstfile
-    character*80           ::  S1_filename
     character*100          ::  temp
     real,  allocatable         ::  obsstd(:)
     character*1            ::  vid(2)
@@ -101,13 +99,6 @@ contains
     type(pert_dec_type)    :: obs_pert
     real, pointer          :: obs_temp(:,:)
     real, allocatable          :: ssdev(:)
-    real                   :: dx, dy
-    integer                :: NX, NY 
-    integer                :: ncid
-    integer                :: flist
-    integer                :: ios
-    character*100          :: infile 
-    character*100          :: xname, yname 
 
 
     allocate(S1_sigma_struc(LIS_rc%nnest))
@@ -268,26 +259,16 @@ contains
 ! set up the S1 domain %and interpolation weights. 
 !-------------------------------------------------------------
 
-    ! Open first file to get nx ny dimensions
-    call system('ls ./' // trim(S1sigmaobsdir) // ' > ./S1_listfiles.txt')
-
-    open(flist, file=trim('./S1_listfiles.txt'), &
-         status='old', iostat=status)
-
-    read(flist, '(a)', iostat=status) S1_firstfile
-    S1_filename = trim(S1sigmaobsdir) // '/' // trim(S1_firstfile)
-
-    ios = nf90_open(path=S1_filename,&
-                    mode=NF90_NOWRITE,ncid=ncid)
-    call LIS_verify(ios,&
-        'Error reading in S1 data dimensions: Error opening file '// S1_filename)
-    ios = nf90_inquire_dimension(ncid,1,yname,NY)
-    ios = nf90_inquire_dimension(ncid,2,xname,NX)
-    ios = nf90_close(ncid)
-
     do n=1,LIS_rc%nnest
-       S1_sigma_struc(n)%nc = NX
-       S1_sigma_struc(n)%nr = NY
+       call ESMF_ConfigFindLabel(LIS_config,&
+                    "S1 backscatter domain x-dimension size:",rc=status)
+       call ESMF_ConfigGetAttribute(LIS_config,S1_sigma_struc(n)%nc,rc=status)
+       call LIS_verify(status,'[ERR] S1 backscatter domain x-dimension size: not defined')
+
+       call ESMF_ConfigFindLabel(LIS_config,&
+                   "S1 backscatter domain y-dimension size:",rc=status)
+       call ESMF_ConfigGetAttribute(LIS_config,S1_sigma_struc(n)%nr,rc=status)
+       call LIS_verify(status,'[ERR] S1 backscatter domain y-dimension size: not defined')
 
        allocate(S1_sigma_struc(n)%sigma(LIS_rc%obs_lnc(k),LIS_rc%obs_lnr(k)))
        allocate(S1_sigma_struc(n)%sigmatime(&

--- a/lis/dataassim/obs/S1_sigmaVVSM/S1_sigmaVVSM_Mod.F90
+++ b/lis/dataassim/obs/S1_sigmaVVSM/S1_sigmaVVSM_Mod.F90
@@ -90,8 +90,6 @@ contains
     type(ESMF_Field)       ::  pertField(LIS_rc%nnest)
     type(ESMF_ArraySpec)   ::  pertArrSpec
     character*100          ::  S1sigmaobsdir
-    character*80           ::  S1_firstfile
-    character*80           ::  S1_filename
     character*100          ::  temp
     real,  allocatable         ::  obsstd(:)
     character*1            ::  vid(2)
@@ -101,13 +99,6 @@ contains
     type(pert_dec_type)    :: obs_pert
     real, pointer          :: obs_temp(:,:)
     real, allocatable          :: ssdev(:)
-    real                   :: dx, dy
-    integer                :: NX, NY 
-    integer                :: ncid
-    integer                :: flist
-    integer                :: ios
-    character*100          :: infile 
-    character*100          :: xname, yname 
 
 
     allocate(S1_sigma_struc(LIS_rc%nnest))
@@ -268,26 +259,16 @@ contains
 ! set up the S1 domain %and interpolation weights. 
 !-------------------------------------------------------------
 
-    ! Open first file to get nx ny dimensions
-    call system('ls ./' // trim(S1sigmaobsdir) // ' > ./S1_listfiles.txt')
-
-    open(flist, file=trim('./S1_listfiles.txt'), &
-         status='old', iostat=status)
-
-    read(flist, '(a)', iostat=status) S1_firstfile
-    S1_filename = trim(S1sigmaobsdir) // '/' // trim(S1_firstfile)
-
-    ios = nf90_open(path=S1_filename,&
-                    mode=NF90_NOWRITE,ncid=ncid)
-    call LIS_verify(ios,&
-        'Error reading in S1 data dimensions: Error opening file '// S1_filename)
-    ios = nf90_inquire_dimension(ncid,1,yname,NY)
-    ios = nf90_inquire_dimension(ncid,2,xname,NX)
-    ios = nf90_close(ncid)
-
     do n=1,LIS_rc%nnest
-       S1_sigma_struc(n)%nc = NX
-       S1_sigma_struc(n)%nr = NY
+       call ESMF_ConfigFindLabel(LIS_config,&
+                    "S1 backscatter domain x-dimension size:",rc=status)
+       call ESMF_ConfigGetAttribute(LIS_config,S1_sigma_struc(n)%nc,rc=status)
+       call LIS_verify(status,'[ERR] S1 backscatter domain x-dimension size: not defined')
+
+       call ESMF_ConfigFindLabel(LIS_config,&
+                   "S1 backscatter domain y-dimension size:",rc=status)
+       call ESMF_ConfigGetAttribute(LIS_config,S1_sigma_struc(n)%nr,rc=status)
+       call LIS_verify(status,'[ERR] S1 backscatter domain y-dimension size: not defined')
 
        allocate(S1_sigma_struc(n)%sigma(LIS_rc%obs_lnc(k),LIS_rc%obs_lnr(k)))
        allocate(S1_sigma_struc(n)%sigmatime(&

--- a/lis/dataassim/obs/S1_sigmaVVSMLAI/S1_sigmaVVSMLAI_Mod.F90
+++ b/lis/dataassim/obs/S1_sigmaVVSMLAI/S1_sigmaVVSMLAI_Mod.F90
@@ -90,8 +90,6 @@ contains
     type(ESMF_Field)       ::  pertField(LIS_rc%nnest)
     type(ESMF_ArraySpec)   ::  pertArrSpec
     character*100          ::  S1sigmaobsdir
-    character*80           ::  S1_firstfile
-    character*80           ::  S1_filename
     character*100          ::  temp
     real,  allocatable         ::  obsstd(:)
     character*1            ::  vid(2)
@@ -101,13 +99,6 @@ contains
     type(pert_dec_type)    :: obs_pert
     real, pointer          :: obs_temp(:,:)
     real, allocatable          :: ssdev(:)
-    real                   :: dx, dy
-    integer                :: NX, NY 
-    integer                :: ncid
-    integer                :: flist
-    integer                :: ios
-    character*100          :: infile 
-    character*100          :: xname, yname 
 
     allocate(S1_sigma_struc(LIS_rc%nnest))
 
@@ -267,26 +258,16 @@ contains
 ! set up the S1 domain %and interpolation weights. 
 !-------------------------------------------------------------
 
-    ! Open first file to get nx ny dimensions
-    call system('ls ./' // trim(S1sigmaobsdir) // ' > ./S1_listfiles.txt')
-
-    open(flist, file=trim('./S1_listfiles.txt'), &
-         status='old', iostat=status)
-
-    read(flist, '(a)', iostat=status) S1_firstfile
-    S1_filename = trim(S1sigmaobsdir) // '/' // trim(S1_firstfile)
-
-    ios = nf90_open(path=S1_filename,&
-                    mode=NF90_NOWRITE,ncid=ncid)
-    call LIS_verify(ios,&
-        'Error reading in S1 data dimensions: Error opening file '// S1_filename)
-    ios = nf90_inquire_dimension(ncid,1,yname,NY)
-    ios = nf90_inquire_dimension(ncid,2,xname,NX)
-    ios = nf90_close(ncid)
-
     do n=1,LIS_rc%nnest
-       S1_sigma_struc(n)%nc = NX
-       S1_sigma_struc(n)%nr = NY
+       call ESMF_ConfigFindLabel(LIS_config,&
+                    "S1 backscatter domain x-dimension size:",rc=status)
+       call ESMF_ConfigGetAttribute(LIS_config,S1_sigma_struc(n)%nc,rc=status)
+       call LIS_verify(status,'[ERR] S1 backscatter domain x-dimension size: not defined')
+
+       call ESMF_ConfigFindLabel(LIS_config,&
+                   "S1 backscatter domain y-dimension size:",rc=status)
+       call ESMF_ConfigGetAttribute(LIS_config,S1_sigma_struc(n)%nr,rc=status)
+       call LIS_verify(status,'[ERR] S1 backscatter domain y-dimension size: not defined')
 
        allocate(S1_sigma_struc(n)%sigma(LIS_rc%obs_lnc(k),LIS_rc%obs_lnr(k)))
        allocate(S1_sigma_struc(n)%sigmatime(&

--- a/lis/dataassim/obs/S1_sigmaVVVHSMLAI/S1_sigmaVVVHSMLAI_Mod.F90
+++ b/lis/dataassim/obs/S1_sigmaVVVHSMLAI/S1_sigmaVVVHSMLAI_Mod.F90
@@ -92,8 +92,6 @@ contains
     type(ESMF_Field)       ::  pertField(LIS_rc%nnest)
     type(ESMF_ArraySpec)   ::  pertArrSpec
     character*100          ::  S1sigmaobsdir
-    character*80           ::  S1_firstfile
-    character*80           ::  S1_filename
     character*100          ::  temp
     real,  allocatable         ::  obsstd(:)
     character*1            ::  vid(2)
@@ -103,13 +101,6 @@ contains
     type(pert_dec_type)    :: obs_pert
     real, pointer          :: obs_temp(:,:)
     real, allocatable          :: ssdev(:)
-    real                   :: dx, dy
-    integer                :: NX, NY 
-    integer                :: ncid
-    integer                :: flist
-    integer                :: ios
-    character*100          :: infile 
-    character*100          :: xname, yname 
 
     allocate(S1_sigma_struc(LIS_rc%nnest))
 
@@ -284,26 +275,16 @@ contains
 ! set up the S1 domain %and interpolation weights. 
 !-------------------------------------------------------------
 
-    ! Open first file to get nx ny dimensions
-    call system('ls ./' // trim(S1sigmaobsdir) // ' > ./S1_listfiles.txt')
-
-    open(flist, file=trim('./S1_listfiles.txt'), &
-         status='old', iostat=status)
-
-    read(flist, '(a)', iostat=status) S1_firstfile
-    S1_filename = trim(S1sigmaobsdir) // '/' // trim(S1_firstfile)
-
-    ios = nf90_open(path=S1_filename,&
-                    mode=NF90_NOWRITE,ncid=ncid)
-    call LIS_verify(ios,&
-        'Error reading in S1 data dimensions: Error opening file '// S1_filename)
-    ios = nf90_inquire_dimension(ncid,1,yname,NY)
-    ios = nf90_inquire_dimension(ncid,2,xname,NX)
-    ios = nf90_close(ncid)
-
     do n=1,LIS_rc%nnest
-       S1_sigma_struc(n)%nc = NX
-       S1_sigma_struc(n)%nr = NY
+       call ESMF_ConfigFindLabel(LIS_config,&
+                    "S1 backscatter domain x-dimension size:",rc=status)
+       call ESMF_ConfigGetAttribute(LIS_config,S1_sigma_struc(n)%nc,rc=status)
+       call LIS_verify(status,'[ERR] S1 backscatter domain x-dimension size: not defined')
+
+       call ESMF_ConfigFindLabel(LIS_config,&
+                   "S1 backscatter domain y-dimension size:",rc=status)
+       call ESMF_ConfigGetAttribute(LIS_config,S1_sigma_struc(n)%nr,rc=status)
+       call LIS_verify(status,'[ERR] S1 backscatter domain y-dimension size: not defined')
 
        allocate(S1_sigma_struc(n)%s_vv(LIS_rc%obs_lnc(k),LIS_rc%obs_lnr(k)))
        allocate(S1_sigma_struc(n)%s_vh(LIS_rc%obs_lnc(k),LIS_rc%obs_lnr(k)))


### PR DESCRIPTION
This PR solves a bug related to the domain definition of all S1-related observations (S1_SNWD, S1_sigmaVHSM, S1_sigmaVHSMLAI, S1_sigmaVVSM, S1_sigmaVVSMLAI, S1_sigmaVVVHSMLAI).

### Problem
Previously, the first file netcdf file of the S1 directory was read to define the number of rows and columns of all files. This was done by listing the content of the directory into a new text file (S1_listfiles.txt) to get the first file of the directory. This created problems when using many MPI processes.

### Fix
The number of rows and columns of S1 observation files (snow depth and backscatter) are now defined as an entry in the lis.config file as in the following example:
```
#Observation specifications
#S1 snow depth
S1 snow depth data directory:           "./S1_snd_directory"
S1 snow depth domain x-dimension size:  6144
S1 snow depth domain y-dimension size:  2304

#S1 backscatter
S1 backscatter data directory:          "./S1_backscatter_directory"
S1 backscatter domain x-dimension size: 689
S1 backscatter domain y-dimension size: 337
```
When the number of rows/cols are not defined, the LIS run stops and an error in given in the lislog file, e.g.

> [ERR] S1 snow depth domain x-dimension size: not defined

### Testing
The code was tested on an OL run (excluding increments) using two DA instances: "S1 backscatter VVSM" and "S1 snow depth".  The setup was tested on Hortense Tier1 using 120 processes. The surface soil moisture increments were compared to those of the original run and are identical, meaning that the reading of the S1 backscatter is correct. 

**Note**: all users recompiling LIS from this version and using S1 DA must add the new entries in the lis.config file!

