### PR TITLE
remove interpolation in snow depth reader

### DIFF
--- a/lis/dataassim/obs/S1_SNWD/read_S1_SNWD.F90
+++ b/lis/dataassim/obs/S1_SNWD/read_S1_SNWD.F90
@@ -294,7 +294,6 @@ subroutine read_S1_SNWD_data(n, k, fname, snwd_ip)
   real                        :: lat_nc(S1_SNWD_struc(n)%nr)
   real                        :: lon_nc(S1_SNWD_struc(n)%nc)
   real                        :: snwd_ip(LIS_rc%obs_lnc(k),LIS_rc%obs_lnr(k))
-  real                        :: snwd_fill(LIS_rc%obs_lnc(k),LIS_rc%obs_lnr(k))
   integer                     :: nsnwd_ip(LIS_rc%obs_lnc(k),LIS_rc%obs_lnr(k))
   logical                     :: file_exists
   integer                     :: c,r,i,j
@@ -349,17 +348,10 @@ subroutine read_S1_SNWD_data(n, k, fname, snwd_ip)
 
 
 
-!     ! Initialize 
-!     do r=1,LIS_rc%obs_lnr(k)
-!        do c=1,LIS_rc%obs_lnc(k)
-!           nsnwd_ip(c,r) = 0
-!           snwd_ip(c,r) = 0.0
-!        enddo
-!     enddo
      snwd_ip = 0
      nsnwd_ip = 0
 
-     ! Interpolate the data by averaging 
+     ! Map the data by averaging 
      do i=1,S1_SNWD_struc(n)%nr
         do j=1,S1_SNWD_struc(n)%nc
               


### PR DESCRIPTION
<!--
  Before opening a pull request...
  * Open an Issue (if one doesn't already exist).
  * Resolve any merge conflicts indicated on this page.
  * Select the appropriate base branch above: master or support/*
    (see the Working with GitHub guide in docs/ for more)
-->

### Issue
The interpolation was originally implemented to fill striping in the S1 SD observations that appeared after regridding in the reader. However in combination with the wet snow mask the filling of empty pixels caused pixels that were masked for wet snow conditions to be filled with S1 SD values from its neighbors (in case the neighboring pixels have dry snow or no snow according to the S1 SD retrievals). 

### Solution
The interpolation was removed from the reader. If a pixel is classified as wet snow by the S1 SD retrieval algorithm, the gap will not be filled with values from its neighbors, and no SD observation will be assimilated. 
However, when the LIS grid and the S1 SD retrieval grid don't match, some pixels might not have observations.
 
### Testcase
A testcase was done and showed improved performance of DA after the interpolation was removed.

<!-- Include "closing keywords" (e.g., Resolves #100) to link an open Issue. -->
<!-- This will automatically close the Issue when the PR is merged. -->


