### PR TITLE
ENH: Enable bottom temperature as output variable for NoahMP 4.0.1

### DIFF
--- a/lis/surfacemodels/land/noahmp.4.0.1/NoahMP401_main.F90
+++ b/lis/surfacemodels/land/noahmp.4.0.1/NoahMP401_main.F90
@@ -1346,6 +1346,10 @@ subroutine NoahMP401_main(n)
             call LIS_diagnoseSurfaceOutputVar(n, t, LIS_MOC_QA, value = tmp_pah, &
                   vlevel=1, unit="W m-2",direction="DN",surface_type=LIS_rc%lsm_index)
 
+            call LIS_diagnoseSurfaceOutputVar(n, t, LIS_MOC_TEMPBOT,   &
+                  value=tmp_tbot, vlevel=1, unit="K",                  &
+                  direction="-", surface_type=LIS_rc%lsm_index)
+
 ! Added water balance change terms - David Mocko
             endsm = 0.0
             do i = 1,tmp_nsoil


### PR DESCRIPTION
In order to make our LIS version compatible with NU-WRF, bottom temperature has to be enabled as output variable.