### PR TITLE
Irrigation with multiple land cover maps

### DIFF
--- a/lis/irrigation/sprinkler/sprinkler_irrigationMod.F90
+++ b/lis/irrigation/sprinkler/sprinkler_irrigationMod.F90
@@ -452,8 +452,9 @@ contains
        write(LIS_logunit,*) "[ERR] is not supported for irrigation. Stopping program ... "
        call LIS_endrun()
     end select
+    ! SM 13062024 allows to associate different land cover maps to CROPMAP classification   
   ! Assign default 32 UMD+CROPMAP for now, due to indexing for max root depth input files:
-    total_vegtypes = 13 + LIS_rc%numbercrops
+    !total_vegtypes = 13 + LIS_rc%numbercrops
 
     allocate(l_croptype(LIS_rc%lnc(n),LIS_rc%lnr(n)))
 


### PR DESCRIPTION
<!--
  Before opening a pull request...
  * Open an Issue (if one doesn't already exist).
  * Resolve any merge conflicts indicated on this page.
  * Select the appropriate base branch above: master or support/*
    (see the Working with GitHub guide in docs/ for more)
-->

### PR to allow irrigation with multiple land covers.

This PR includes a single change which allows to use the CROPMAP CONSTANT classification with multiple land covers to activate irrigation in LIS.  

Note that the method works well with an input LDT file built with CROPMAP classification and "CONSTANT" croptype data source. A pixel by pixel crop type classification (i.e., not constant) is only allowed for the AVHRR UMD classification (i.e.,Crop type data source: UMDCROPMAP) and not for the MODIS IGBP LC map.

