### PR TITLE
BUG: replacing uninitialized variable in Noah-MP401 irrigation module

### DIFF
--- a/lis/surfacemodels/land/noahmp.4.0.1/irrigation/noahmp401_getirrigationstates.F90
+++ b/lis/surfacemodels/land/noahmp.4.0.1/irrigation/noahmp401_getirrigationstates.F90
@@ -210,7 +210,7 @@ subroutine noahmp401_getirrigationstates(n,irrigState)
       (soil_moisture_pert .and. (LIS_rc%pert_bias_corr.eq.0)))  then
   	  do i=1,LIS_rc%npatch(n,LIS_rc%lsm_index)
 		 t = i
-		 timestep = NOAHMP401_struc(n)%dt
+		 timestep = NOAHMP401_struc(n)%ts
 		 soiltyp = noahmp401_struc(n)%noahmp401(t)%soiltype
 		
 	 
@@ -548,7 +548,7 @@ subroutine noahmp401_getirrigationstates(n,irrigState)
 
 			t=(i-1)*LIS_rc%nensem(n)+m
 
-		 timestep = NOAHMP401_struc(n)%dt
+		 timestep = NOAHMP401_struc(n)%ts
 		 soiltyp = noahmp401_struc(n)%noahmp401(t)%soiltype
 		
 	 


### PR DESCRIPTION
### Description
In _noahmp401_getirrigationstates.F90_, NOAHMP401_struc(n)%dt is used but it is not initialized. This caused a random(?) behavior and affected the if statement at line 701. 

In Noah-MP v3.6, this variable gets initialized and is set equal to NOAHMP36_struc(n)%ts. Therefore, **I replaced NOAHMP401_struc(n)%dt by NOAHMP401_struc(n)%ts** (the land surface model time step). 

Similarly, the variable was also replaced in the second block related to ensemble runs with soil moisture perturbations.

Note that I don't understand why this only occurs with the tiling ON... From experience, I can say that uninitialized variables often result in unpredictable behaviors, also depending on the system/compiler.

### Testcase
Tested for the period Jan 1990 through Jun 1990 on two setups: (1) 36 processors (6x6), (2) 24 processors (6x4). Results are identical.
![Picture2](https://github.com/user-attachments/assets/4840ad2a-58f1-40f6-bf3f-bc697e01474c)



