### PR TITLE
BUG: rooting depth drop to zero issue in GDD

### DIFF
--- a/lis/surfacemodels/land/ac.7.2/ac_modules/run.f90
+++ b/lis/surfacemodels/land/ac.7.2/ac_modules/run.f90
@@ -6981,7 +6981,13 @@ subroutine AdvanceOneTimeStep(WPi, HarvestNow)
                 end if
              end if
         else
-           call SetRootingDepth(0._sp)
+           ! In GDD mode, SumGDD needs to be higher than GDDaysToHarvest to prevent reset to zero before harvest
+            if ((GetCrop_ModeCycle() == modeCycle_GDDays) .and. &
+                (GetSimulation_SumGDD() < GetCrop_GDDaysToHarvest())) then
+                call SetRootingDepth(GetZiprev())
+            else
+                call SetRootingDepth(0._sp)
+            end if
         end if
     else
         call SetRootingDepth(GetZiprev())


### PR DESCRIPTION
This PR fixes a bug that is visible sporadically in space and time in GDD mode when rooting depth drops to zero right before harvest.
The bug originates from a mismatch in the 'within season checks' in section 7 of the run.f90
It occurs for some pixels and years that SumGDD is still smaller than GDDaysToHarvest while (DayNri-Simulation.DelayedDays) is already larger than Crop.DayN.
This leads to entering the else of the inner if statement which sets rooting depth to zero.
In GDD mode, it only affects the last day before harvest when rooting depth drops to zero and then jumps back again to the original depth it had before the drop.