### PR TITLE
ENH: Align LISF ac_modules with AquaCrop LIS-AC

### DIFF
--- a/lis/surfacemodels/land/ac.7.2/ac72_setup.F90
+++ b/lis/surfacemodels/land/ac.7.2/ac72_setup.F90
@@ -1077,7 +1077,7 @@ subroutine AC72_setup()
 
         ! Check if temperatures are high enough for crop production from Trecord
         ! Get base temperature
-        frac_lower = real(count( ((AC72_struc(n)%ac72(t)%Tmin_record + AC72_struc(n)%ac72(t)%Tmin_record)/2. > &
+        frac_lower = real(count( ((AC72_struc(n)%ac72(t)%Tmax_record + AC72_struc(n)%ac72(t)%Tmin_record)/2. > &
                               AC72_struc(n)%ac72(t)%tbase) )) / 366.
 
         if (frac_lower.lt.0.1) then

--- a/lis/surfacemodels/land/ac.7.2/ac_modules/global.f90
+++ b/lis/surfacemodels/land/ac.7.2/ac_modules/global.f90
@@ -4816,7 +4816,7 @@ subroutine LoadCrop(FullName)
     character(len=*), intent(in) :: FullName
 
     integer :: fhandle
-    integer(int32) :: XX, YY
+    integer(int32) :: XX, YY, rc
     real(sp) :: VersionNr
     integer(int8) :: TempShortInt, perenperiod_onsetOcc_temp
     integer(int8) :: perenperiod_endOcc_temp
@@ -4830,6 +4830,7 @@ subroutine LoadCrop(FullName)
     real(sp) :: perenperiod_onsetTV_temp, perenperiod_endTV_temp
     real(sp) :: Crop_SmaxTop_temp, Crop_SmaxBot_temp
     character(len=1024) :: CropDescriptionLocal
+    character(len=64) :: buffer
 
     open(newunit=fhandle, file=trim(FullName), status='old', action='read')
     read(fhandle, '(a)') CropDescriptionLocal
@@ -4887,8 +4888,12 @@ subroutine LoadCrop(FullName)
 
     ! required growing degree days to complete the crop cycle
     ! (is identical as to maturity)
-    read(fhandle, *) TempInt
-    call SetCrop_GDDaysToHarvest(TempInt)
+    ! When 'External' is set for GDD parameters, do not set GDD Crop parameters
+    read(fhandle, '(A)') buffer
+    read(buffer, *, iostat=rc) TempInt
+    if (rc == 0) then
+       call SetCrop_GDDaysToHarvest(TempInt)
+    endif
 
     ! water stress
     read(fhandle, *) TempDouble
@@ -5132,22 +5137,49 @@ subroutine LoadCrop(FullName)
     end if
 
     ! growing degree days
-    read(fhandle, *) TempInt
-    call SetCrop_GDDaysToGermination(TempInt)
-    read(fhandle, *) TempInt
-    call SetCrop_GDDaysToMaxRooting(TempInt)
-    read(fhandle, *) TempInt
-    call SetCrop_GDDaysToSenescence(TempInt)
-    read(fhandle, *) TempInt
-    call SetCrop_GDDaysToHarvest(TempInt)
+    ! When 'External' is set for GDD parameters, do not set GDD Crop parameters
+    read(fhandle, '(A)') buffer
+    read(buffer, *, iostat=rc) TempInt
+    if (rc == 0) then
+       call SetCrop_GDDaysToGermination(TempInt)
+    endif
+    ! When 'External' is set for GDD parameters, do not set GDD Crop parameters
+    read(fhandle, '(A)') buffer
+    read(buffer, *, iostat=rc) TempInt
+    if (rc == 0) then
+       call SetCrop_GDDaysToMaxRooting(TempInt)
+    endif
+    ! When 'External' is set for GDD parameters, do not set GDD Crop parameters
+    read(fhandle, '(A)') buffer
+    read(buffer, *, iostat=rc) TempInt
+    if (rc == 0) then
+       call SetCrop_GDDaysToSenescence(TempInt)
+    endif
+    ! When 'External' is set for GDD parameters, do not set GDD Crop parameters
+    read(fhandle, '(A)') buffer
+    read(buffer, *, iostat=rc) TempInt
+    if (rc == 0) then
+       call SetCrop_GDDaysToHarvest(TempInt)
+    endif
+
     read(fhandle, *) TempInt
     call SetCrop_GDDaysToFlowering(TempInt)
     read(fhandle, *) TempInt
     call SetCrop_GDDLengthFlowering(TempInt)
-    read(fhandle, *) TempDouble
-    call SetCrop_GDDCGC(TempDouble)
-    read(fhandle, *) TempDouble
-    call SetCrop_GDDCDC(TempDouble)
+
+    ! When 'External' is set for GDD parameters, do not set GDD Crop parameters
+    read(fhandle, '(A)') buffer
+    read(buffer, *, iostat=rc) TempDouble
+    if (rc == 0) then
+       call SetCrop_GDDCGC(TempDouble)
+    endif
+    ! When 'External' is set for GDD parameters, do not set GDD Crop parameters
+    read(fhandle, '(A)') buffer
+    read(buffer, *, iostat=rc) TempDouble
+    if (rc == 0) then
+       call SetCrop_GDDCDC(TempDouble)
+    endif
+
     read(fhandle, *) TempInt
     call SetCrop_GDDaysToHIo(TempInt)
 

--- a/lis/surfacemodels/land/ac.7.2/ac_modules/run.f90
+++ b/lis/surfacemodels/land/ac.7.2/ac_modules/run.f90
@@ -7022,7 +7022,8 @@ subroutine AdvanceOneTimeStep(WPi, HarvestNow)
         else
            ! In GDD mode, SumGDD needs to be higher than GDDaysToHarvest to prevent reset to zero before harvest
             if ((GetCrop_ModeCycle() == modeCycle_GDDays) .and. &
-                (GetSimulation_SumGDD() < GetCrop_GDDaysToHarvest())) then
+                (GetSimulation_SumGDD() < GetCrop_GDDaysToHarvest()) .and. &
+                (GetSimulation_SumGDD() >= GetCrop_GDDaysToSenescence())) then
                 call SetRootingDepth(GetZiprev())
             else
                 call SetRootingDepth(0._sp)

--- a/lis/surfacemodels/land/ac.7.2/ac_modules/run.f90
+++ b/lis/surfacemodels/land/ac.7.2/ac_modules/run.f90
@@ -5,11 +5,18 @@ use ac_climprocessing, only:    GetDecadeEToDataset, &
                                 GetMonthlyEToDataset, &
                                 GetMonthlyRainDataset
 use ac_global, only:    AdjustSizeCompartments, &
+                        AdjustClimRecordTo, &
                         ac_zero_threshold, &
+                        GetClimateFile, &
+                        GetClimFile, &
+                        GetClimRecord_NrObs, &
                         GetCrop_DaysToHIo, &
                         GetCrop_GDDaysToHIo, &
+                        GetCropFileSet, &
                         GetOut8Irri, &
+                        GetSimulation_Germinate, &
                         CompartmentIndividual, &
+                        CompleteCropDescription, &
                         datatype_daily, &
                         datatype_decadely, &
                         datatype_monthly, &
@@ -212,6 +219,14 @@ use ac_global, only:    AdjustSizeCompartments, &
                         GetSimulation_NrRuns, &
                         SetTmax, &
                         SetTmin, &
+                        SetCrop_DayN, &
+                        SetCrop_DaysToSenescence, &
+                        SetCrop_DaysToHarvest, &
+                        SetCrop_GDDaysToSenescence, &
+                        SetCrop_GDDaysToHarvest, &
+                        SetSimulation_ToDayNr, & 
+                        SetSimulParam_Tmin, &
+                        SetSimulParam_Tmax, &
                         SplitStringInThreeParams, &
                         SplitStringInTwoParams, &
                         subkind_Grain, &
@@ -232,6 +247,7 @@ use ac_global, only:    AdjustSizeCompartments, &
                         SetCrop_pSenAct, &
                         GetCrop_pSenescence, &
                         SetCrop_pLeafAct, &
+                        SetCrop_Day1, &
                         GetCrop_pLeafDefUL, &
                         CO2ForSimulationPeriod, &
                         GetCrop_ECemax, &
@@ -413,10 +429,14 @@ use ac_rootunit, only:  AdjustedRootingDepth
 use ac_simul,    only:  Budget_module, &
                         determinepotentialbiomass, &
                         determinebiomassandyield
-use ac_tempprocessing, only:    GetDecadeTemperatureDataSet, &
+use ac_tempprocessing, only:    AdjustCalendarCrop, &
+                                AdjustCropFileParameters, &
+                                GetDecadeTemperatureDataSet, &
                                 GetMonthlyTemperaturedataset, &
                                 GrowingDegreeDays, &
                                 LoadSimulationRunProject, &
+                                MaxAvailableGDD, &
+                                ResetCropDay1, &
                                 temperaturefilecoveringcropperiod, &
                                 GetTminDataSet, & 
                                 GetTmaxDataSet, &
@@ -561,6 +581,7 @@ integer(int32) :: IrriInterval
 integer(int32) :: Tadj, GDDTadj
 integer(int32) :: DayLastCut,NrCut,SumInterval
 integer(int32)  :: PreviousStressLevel, StressSFadjNEW
+integer(int32) :: RepeatToDay
 
 real(sp) :: Bin
 real(sp) :: Bout
@@ -2228,6 +2249,18 @@ subroutine SetDayNri(DayNri_in)
     DayNri = DayNri_in
 end subroutine SetDayNri
 
+
+integer(int32) function GetRepeatToDay()
+
+    GetRepeatToDay = RepeatToDay
+end function GetRepeatToDay
+
+
+subroutine SetRepeatToDay(RepeatToDay_in)
+    integer(int32), intent(in) :: RepeatToDay_in
+
+    RepeatToDay = RepeatToDay_in
+end subroutine SetRepeatToDay
 
 ! EToDataSet
 
@@ -4339,19 +4372,6 @@ subroutine FinalizeRun2(NrRun, TheProjectType)
     end subroutine CloseEvalDataPerformEvaluation
 
 
-    subroutine CloseClimateFiles()
-        if (GetEToFile() /= '(None)') then
-            call fEToSIM_close()
-        end if
-        if (GetRainFile() /= '(None)') then
-            call fRainSIM_close()
-        end if
-        if (GetTemperatureFile() /= '(None)') then
-            call fTempSIM_close()
-        end if
-    end subroutine CloseClimateFiles
-
-
     subroutine CloseIrrigationFile()
         if ((GetIrriMode() == IrriMode_Manual) .or. (GetIrriMode() == IrriMode_Generate)) then
             call fIrri_close()
@@ -4365,6 +4385,19 @@ subroutine FinalizeRun2(NrRun, TheProjectType)
         end if
     end subroutine CloseManagementFile
 end subroutine FinalizeRun2
+
+
+subroutine CloseClimateFiles()
+    if (GetEToFile() /= '(None)') then
+        call fEToSIM_close()
+    end if
+    if (GetRainFile() /= '(None)') then
+        call fRainSIM_close()
+    end if
+    if (GetTemperatureFile() /= '(None)') then
+        call fTempSIM_close()
+    end if
+end subroutine CloseClimateFiles
 
 
 subroutine OpenIrrigationFile()
@@ -4851,18 +4884,24 @@ subroutine InitializeSimulationRunPart1()
     end if
 
     ! Maximum sum Kc (for reduction WP in season if soil fertility stress)
-    call SetSumKcTop(SeasonalSumOfKcPot(GetCrop_DaysToCCini(), &
-            GetCrop_GDDaysToCCini(), GetCrop_DaysToGermination(), &
-            GetCrop_DaysToFullCanopy(), GetCrop_DaysToSenescence(), &
-            GetCrop_DaysToHarvest(), GetCrop_GDDaysToGermination(), &
-            GetCrop_GDDaysToFullCanopy(), GetCrop_GDDaysToSenescence(), &
-            GetCrop_GDDaysToHarvest(), GetCrop_CCo(), GetCrop_CCx(), &
-            GetCrop_CGC(), GetCrop_GDDCGC(), GetCrop_CDC(), GetCrop_GDDCDC(), &
-            GetCrop_KcTop(), GetCrop_KcDecline(), real(GetCrop_CCEffectEvapLate(),kind=sp), &
-            GetCrop_Tbase(), GetCrop_Tupper(), GetSimulParam_Tmin(), &
-            GetSimulParam_Tmax(), GetCrop_GDtranspLow(), GetCO2i(), &
-            GetCrop_ModeCycle(), .true.))
-    call SetSumKcTopStress( GetSumKcTop() * GetFracBiomassPotSF())
+    if ((GetCrop_StressResponse_Calibrated() .eqv. .true.) .and. & 
+        (GetManagement_FertilityStress() > 0_int32)) then
+        call SetSumKcTop(SeasonalSumOfKcPot(GetCrop_DaysToCCini(), &
+                GetCrop_GDDaysToCCini(), GetCrop_DaysToGermination(), &
+                GetCrop_DaysToFullCanopy(), GetCrop_DaysToSenescence(), &
+                GetCrop_DaysToHarvest(), GetCrop_GDDaysToGermination(), &
+                GetCrop_GDDaysToFullCanopy(), GetCrop_GDDaysToSenescence(), &
+                GetCrop_GDDaysToHarvest(), GetCrop_CCo(), GetCrop_CCx(), &
+                GetCrop_CGC(), GetCrop_GDDCGC(), GetCrop_CDC(), GetCrop_GDDCDC(), &
+                GetCrop_KcTop(), GetCrop_KcDecline(), real(GetCrop_CCEffectEvapLate(),kind=sp), &
+                GetCrop_Tbase(), GetCrop_Tupper(), GetSimulParam_Tmin(), &
+                GetSimulParam_Tmax(), GetCrop_GDtranspLow(), GetCO2i(), &
+                GetCrop_ModeCycle(), .true.))
+        call SetSumKcTopStress( GetSumKcTop() * GetFracBiomassPotSF())
+    else
+        call SetSumKcTop(real(undef_int, kind=sp))
+        call SetSumKcTopStress(real(undef_int, kind=sp))
+    endif
     call SetSumKci(0._sp)
 
     ! 7. weed infestation and self-thinning of herbaceous perennial forage crops
@@ -7340,6 +7379,12 @@ subroutine AdvanceOneTimeStep(WPi, HarvestNow)
         call GetPotValSF((VirtualTimeCC+GetSimulation_DelayedDays() + 1), &
                SumGDDAdjCC, PotValSF)
     end if
+    ! Adjust crop cycle and simulation period to delayed days after germination
+    if ((GetSimulation_DelayedDays() > 0) .and. (GetSimulation_Germinate() .eqv. .true.)) then
+        call ResetCropAndSimulationPeriod(GetDayNri());
+        call SetRepeatToDay(GetSimulation_ToDayNr());
+    end if
+
     ! 14.d Print ---------------------------------------
     if (GetOutputAggregate() > 0) then
         call CheckForPrint(GetTheProjectFile())
@@ -7865,7 +7910,6 @@ end subroutine WriteIrrInfo
 
 subroutine FileManagement()
 
-    integer(int32) :: RepeatToDay
     real(sp) :: WPi
     logical :: HarvestNow
 
@@ -7889,6 +7933,7 @@ subroutine RunSimulation(TheProjectFile_, TheProjectType)
     integer(int8) :: NrRun
     integer(int32) :: NrRuns
 
+    call SetNextSimFromDayNr(undef_int)
     call InitializeSimulation(TheProjectFile_, TheProjectType)
 
     select case (TheProjectType)
@@ -7911,5 +7956,106 @@ subroutine RunSimulation(TheProjectFile_, TheProjectType)
 end subroutine RunSimulation
 
 
+subroutine ResetCropAndSimulationPeriod(NewCropDay1)
+    integer(int32), intent(in) :: NewCropDay1
+
+    integer(int32) :: ResettedCropDay1
+    real(sp)       :: GDDAvailable
+    integer(int32) :: LseasonDays
+    integer(int32) :: Crop_DaysToSenescence_temp, Crop_DaysToHarvest_temp
+    integer(int32) :: Crop_GDDaysToSenescence_temp, Crop_GDDaysToHarvest_temp
+    integer(int32) :: FertStress
+    integer(int8)  :: RedCGC_temp, RedCCX_temp
+    integer(int32) :: Crop_DaysToFullCanopySF_temp
+    integer(int32) :: FromDayNr_temp
+    real(sp)       :: TDayMin_temp
+    real(sp)       :: TDayMax_temp
+
+    ! 1. Reset Day1 of Crop cycle
+    call SetCrop_Day1(NewCropDay1)
+    ! 2. Adjust crop calendar
+    if (GetCrop_subkind() == subkind_Forage) then
+        LseasonDays = GetCrop_DayN() - GetCrop_Day1() + 1
+        Crop_DaysToSenescence_temp = GetCrop_DaysToSenescence()
+        Crop_DaysToHarvest_temp = GetCrop_DaysToHarvest()
+        Crop_GDDaysToSenescence_temp = GetCrop_GDDaysToSenescence()
+        Crop_GDDaysToHarvest_temp = GetCrop_GDDaysToHarvest()
+        call AdjustCropFileParameters(GetCropFileSet(),&
+              LseasonDays, GetCrop_Day1(), &
+              GetCrop_ModeCycle(), GetCrop_Tbase(), GetCrop_Tupper(),&
+              Crop_DaysToSenescence_temp, Crop_DaysToHarvest_temp,&
+              Crop_GDDaysToSenescence_temp, Crop_GDDaysToHarvest_temp)
+        call SetCrop_DaysToSenescence(Crop_DaysToSenescence_temp)
+        call SetCrop_DaysToHarvest(Crop_DaysToHarvest_temp)
+        call SetCrop_GDDaysToSenescence(Crop_GDDaysToSenescence_temp)
+        call SetCrop_GDDaysToHarvest(Crop_GDDaysToHarvest_temp)
+        call CompleteCropDescription()
+    else
+        ! 2. Adjust crop calendar (in days) to thermal regime when running in GDDays
+        if ((GetCrop_ModeCycle() == modeCycle_GDDays) .and. (GetClimateFile() /= '(None)')) then
+            ! GDDays 1.1 Check available GDDays
+            ResettedCropDay1 = ResetCropDay1(NewCropDay1, (.false.))
+            TDayMin_temp = GetSimulParam_Tmin()
+            TDayMax_temp = GetSimulParam_Tmax()
+            GDDAvailable = MaxAvailableGDD(ResettedCropDay1, GetCrop_Tbase(), GetCrop_Tupper(), TDayMin_temp, &
+                           TDayMax_temp)
+            call SetSimulParam_Tmin(TDayMin_temp)
+            call SetSimulParam_Tmax(TDayMax_temp)
+            ! GDDays 1.2. Adjust crop calendar to thermal regime if sufficient GDDays
+            if (GDDAvailable >= GetCrop_GDDaysToHarvest()) then
+                call AdjustCalendarCrop(GetCrop_Day1())
+            end if
+        end if
+    end if
+    ! 3. Reset DayN of Crop
+    call SetCrop_DayN(GetCrop_Day1() + GetCrop_DaysToHarvest() - 1)
+    ! 4. Adjust end of Simulation period
+    if (GetTemperatureFile() /= '(External)') then
+        if (GetCrop_DayN() > GetSimulation_ToDayNr()) then
+            call SetSimulation_ToDayNr(GetCrop_DayN())
+            ! adjusting ClimRecord.'TO' for undefined year with 365 days
+            if ((GetClimFile() /= '(None)') .and. & 
+                (GetClimRecord_FromY() == 1901) .and. (GetClimRecord_NrObs() == 365)) then
+                call AdjustClimRecordTo(GetCrop_DayN())
+            end if
+            call SetNextSimFromDayNr(GetCrop_DayN() + 1) ! The Simulation.FromDayNr for next run if KeepSWC
+        else
+            call SetNextSimFromDayNr(undef_int)
+        end if
+    end if
+    ! 5. reset canopy development to soil fertility
+    FertStress = GetManagement_FertilityStress()
+    RedCGC_temp = GetSimulation_EffectStress_RedCGC()
+    RedCCX_temp = GetSimulation_EffectStress_RedCCX()
+    Crop_DaysToFullCanopySF_temp = GetCrop_DaysToFullCanopySF()
+    call TimeToMaxCanopySF(GetCrop_CCo(), GetCrop_CGC(), GetCrop_CCx(), &
+           GetCrop_DaysToGermination(), GetCrop_DaysToFullCanopy(), &
+           GetCrop_DaysToSenescence(), GetCrop_DaysToFlowering(), &
+           GetCrop_LengthFlowering(), GetCrop_DeterminancyLinked(), &
+           Crop_DaysToFullCanopySF_temp, RedCGC_temp, RedCCX_temp, FertStress)
+    call SetCrop_DaysToFullCanopySF(Crop_DaysToFullCanopySF_temp)
+    call SetManagement_FertilityStress(FertStress)
+    call SetSimulation_EffectStress_RedCGC(RedCGC_temp)
+    call SetSimulation_EffectStress_RedCCX(RedCCX_temp)
+    ! 6. Renew Tcrop.SIM (Temperature file covering crop cycle, used for display crop development in environment)
+    if ((GetTemperatureFile() /= '(None)') .and. (GetTemperatureFile() /= '(External)')) then
+        call TemperatureFileCoveringCropPeriod(GetCrop_Day1(), GetCrop_DayN())
+    end if
+    ! 7. Renew daily climate files (EToData.SIM; RainData.SIM and TempData.SIM) if required
+    if ((GetNextSimFromDayNr() /= undef_int) .and. (GetTemperatureFile() /= '(External)')) then
+        ! If Simulation period was adjusted as well
+        ! rewrite ETo, Rain and Temperture file for the whole simulation period
+        ! Close files
+        call CloseClimateFiles()
+        ! Create files
+        call CreateDailyClimFiles(GetSimulation_FromDayNr(), &
+               GetSimulation_ToDayNr())
+        ! Open files and Find current day
+        call OpenClimFilesAndGetDataFirstDay(GetCrop_Day1())
+    end if
+    ! 8. reset delayed days
+    call SetSimulation_DelayedDays(0)
+    ! ResetCropAndSimulationPeriod
+end subroutine ResetCropAndSimulationPeriod
 
 end module ac_run

--- a/lis/surfacemodels/land/ac.7.2/ac_modules/run.f90
+++ b/lis/surfacemodels/land/ac.7.2/ac_modules/run.f90
@@ -7022,11 +7022,10 @@ subroutine AdvanceOneTimeStep(WPi, HarvestNow)
         else
            ! In GDD mode, SumGDD needs to be higher than GDDaysToHarvest to prevent reset to zero before harvest
             if ((GetCrop_ModeCycle() == modeCycle_GDDays) .and. &
-                (GetSimulation_SumGDD() < GetCrop_GDDaysToHarvest()) .and. &
-                (GetSimulation_SumGDD() >= GetCrop_GDDaysToSenescence())) then
-                call SetRootingDepth(GetZiprev())
-            else
+                (GetSimulation_SumGDD() <= 0.0)) then
                 call SetRootingDepth(0._sp)
+            else
+                call SetRootingDepth(GetZiprev())
             end if
         end if
     else

--- a/lis/surfacemodels/land/ac.7.2/ac_modules/simul.f90
+++ b/lis/surfacemodels/land/ac.7.2/ac_modules/simul.f90
@@ -670,7 +670,7 @@ subroutine DetermineBiomassAndYield(dayi, ETo, TminOnDay, TmaxOnDay, CO2i, &
             ! water stress and fertility stress
             ! LB 24 OCT 2026: avoid division by 0
             if (SumKcTopStress > epsilon(1.0_sp)) then
-                if ((SumKci/real(SumKcTopStress, sp)) < 1._sp) then
+                if ((SumKci/real(SumKcTopStress, sp)) < (1._sp-epsilon(0._sp))) then
                     if (ETo > 0._sp) then
                         SumKci = SumKci + Tact/ETo
                     end if

--- a/lis/surfacemodels/land/ac.7.2/ac_modules/simul.f90
+++ b/lis/surfacemodels/land/ac.7.2/ac_modules/simul.f90
@@ -668,7 +668,7 @@ subroutine DetermineBiomassAndYield(dayi, ETo, TminOnDay, TmaxOnDay, CO2i, &
         WPunlim = WPi       ! no water stress, no fertiltiy stress
         if (GetSimulation_EffectStress_RedWP() > 0._sp) then ! Reductions are zero if no fertility stress
             ! water stress and fertility stress
-            ! LB 24 OCT 2026: avoid division by 0
+            ! LB 24 OCT 2025: avoid division by 0
             if (SumKcTopStress > epsilon(1.0_sp)) then
                 if ((SumKci/real(SumKcTopStress, sp)) < (1._sp-epsilon(0._sp))) then
                     if (ETo > 0._sp) then


### PR DESCRIPTION
This PR incorporates all bug fixes of the PR 360 of the AquaCrop repository that were part of the patch1 of V72
(https://github.com/KUL-RSDA/AquaCrop/pull/360).

In addition, the PR adds if statements to enable the use of externally
defined, spatially variable GDD thresholds.

Finally, this PR aligns the ac_modules implementation in LISF with the
LIS-AC version of AquaCrop:
https://github.com/KUL-RSDA/AquaCrop/tree/LIS-AC (after acceptance of current PR).
